### PR TITLE
Fix monophyly_check crash on trees without support values

### DIFF
--- a/phykit/services/tree/monophyly_check.py
+++ b/phykit/services/tree/monophyly_check.py
@@ -64,12 +64,18 @@ class MonophylyCheck(Tree):
     def get_bootstrap_statistics(
         self,
         clade: Newick.Clade
-    ) -> Dict[str, Union[int, float]]:
+    ) -> Union[Dict[str, Union[int, float]], None]:
         # Use generator for memory efficiency
         bs_vals = [
             terminal.confidence for terminal in clade.get_nonterminals()
             if terminal.confidence is not None
         ]
+
+        # No internal support values to summarize (e.g., a time tree or a
+        # tree with no bootstrap labels); return None so callers report "NA"
+        # support rather than failing to subscript a missing result.
+        if not bs_vals:
+            return None
 
         return calculate_summary_statistics_from_arr(bs_vals)
 
@@ -85,14 +91,25 @@ class MonophylyCheck(Tree):
             temp.append("monophyletic")
         else:
             temp.append("not_monophyletic")
-        temp.append(stats["mean"])
-        temp.append(stats["maximum"])
-        temp.append(stats["minimum"])
-        temp.append(stats["standard_deviation"])
+        # stats is None when the tree has no internal support values to
+        # summarize; monophyly is still well-defined, so report the status
+        # with "NA" support fields rather than crashing.
+        if stats is None:
+            temp.extend([None, None, None, None])
+        else:
+            temp.append(stats["mean"])
+            temp.append(stats["maximum"])
+            temp.append(stats["minimum"])
+            temp.append(stats["standard_deviation"])
         temp.append(diff_tips_between_clade_and_curr_tree)
         res_arr.append(temp)
 
         return res_arr
+
+    @staticmethod
+    def _fmt_support(value: Union[int, float, None]) -> Union[int, float, str]:
+        """Format a support value, rendering a missing (None) value as "NA"."""
+        return "NA" if value is None else round(value, 4)
 
     def print_results(self, res_arr: List[List[Union[str, int, float]]]) -> None:
         if self.json_output:
@@ -100,10 +117,10 @@ class MonophylyCheck(Tree):
             for res in res_arr:
                 row = dict(status=res[0])
                 if len(res) > 1:
-                    row["mean_support"] = round(res[1], 4)
-                    row["max_support"] = round(res[2], 4)
-                    row["min_support"] = round(res[3], 4)
-                    row["stdev_support"] = round(res[4], 4)
+                    row["mean_support"] = None if res[1] is None else round(res[1], 4)
+                    row["max_support"] = None if res[2] is None else round(res[2], 4)
+                    row["min_support"] = None if res[3] is None else round(res[3], 4)
+                    row["stdev_support"] = None if res[4] is None else round(res[4], 4)
                     row["offending_taxa"] = sorted(res[5]) if len(res) > 5 and res[5] else []
                 rows.append(row)
             print_json(dict(rows=rows, results=rows))
@@ -114,11 +131,11 @@ class MonophylyCheck(Tree):
                 if res[5]:
                     res[5].sort()
                     print(
-                        f"{res[0]}\t{round(res[1], 4)}\t{round(res[2], 4)}\t{round(res[3], 4)}\t{round(res[4], 4)}\t{';'.join(res[5])}"
+                        f"{res[0]}\t{self._fmt_support(res[1])}\t{self._fmt_support(res[2])}\t{self._fmt_support(res[3])}\t{self._fmt_support(res[4])}\t{';'.join(res[5])}"
                     )
                 else:
                     print(
-                        f"{res[0]}\t{round(res[1], 4)}\t{round(res[2], 4)}\t{round(res[3], 4)}\t{round(res[4], 4)}"
+                        f"{res[0]}\t{self._fmt_support(res[1])}\t{self._fmt_support(res[2])}\t{self._fmt_support(res[3])}\t{self._fmt_support(res[4])}"
                     )
             except IndexError:
                 print(f"{res[0]}")

--- a/tests/integration/tree/test_monophyly_check_integration.py
+++ b/tests/integration/tree/test_monophyly_check_integration.py
@@ -117,3 +117,54 @@ class TestMonophylyCheck(object):
         assert payload["rows"][0] == payload["results"][0]
         assert payload["results"][0]["status"] == "not_monophyletic"
         assert round(payload["results"][0]["mean_support"], 4) == 95.7143
+
+    @patch("builtins.print")
+    def test_monophyly_check_no_support_values(self, mocked_print):
+        # a tree without internal support values (e.g., a time tree) should
+        # still report monophyly, with "NA" in place of support statistics
+        testargs = [
+            "phykit",
+            "monophyly_check",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.tre",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.monophyly_check.true.txt",
+        ]
+        with patch.object(sys, "argv", testargs):
+            Phykit()
+
+        assert mocked_print.mock_calls == [
+            call("monophyletic\tNA\tNA\tNA\tNA"),
+        ]
+
+    @patch("builtins.print")
+    def test_monophyly_check_no_support_values_not_true(self, mocked_print):
+        testargs = [
+            "phykit",
+            "monophyly_check",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.tre",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.monophyly_check.false.txt",
+        ]
+        with patch.object(sys, "argv", testargs):
+            Phykit()
+
+        assert mocked_print.mock_calls == [
+            call(
+                "not_monophyletic\tNA\tNA\tNA\tNA\tAspergillus_b;Aspergillus_c;Penicillium_e"
+            ),
+        ]
+
+    @patch("builtins.print")
+    def test_monophyly_check_no_support_values_json(self, mocked_print):
+        testargs = [
+            "phykit",
+            "monophyly_check",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.tre",
+            f"{here.parent.parent.parent}/sample_files/small_no_support_tree.monophyly_check.true.txt",
+            "--json",
+        ]
+        with patch.object(sys, "argv", testargs):
+            Phykit()
+
+        payload = json.loads(mocked_print.call_args.args[0])
+        assert payload["results"][0]["status"] == "monophyletic"
+        assert payload["results"][0]["mean_support"] is None
+        assert payload["results"][0]["offending_taxa"] == []

--- a/tests/sample_files/small_no_support_tree.monophyly_check.false.txt
+++ b/tests/sample_files/small_no_support_tree.monophyly_check.false.txt
@@ -1,0 +1,2 @@
+Aspergillus_a
+Penicillium_d

--- a/tests/sample_files/small_no_support_tree.monophyly_check.true.txt
+++ b/tests/sample_files/small_no_support_tree.monophyly_check.true.txt
@@ -1,0 +1,2 @@
+Penicillium_d
+Penicillium_e

--- a/tests/sample_files/small_no_support_tree.tre
+++ b/tests/sample_files/small_no_support_tree.tre
@@ -1,0 +1,1 @@
+((Aspergillus_a:0.1,Aspergillus_b:0.1):0.1,(Aspergillus_c:0.1,(Penicillium_d:0.1,Penicillium_e:0.1):0.1):0.1);


### PR DESCRIPTION
monophyly_check assumed every internal node carried a support value. On a tree with no internal support labels (e.g., a time tree), the support-statistics helper returns None, and populate_res_arr then crashed with `TypeError: 'NoneType' object is not subscriptable` while subscripting stats["mean"].

Monophyly is still well-defined without support values, so:
- get_bootstrap_statistics() now short-circuits to None when there are no internal support values (also avoids the helper's spurious "no values" message on stdout).
- populate_res_arr() emits None placeholders for the support fields when stats is None.
- print_results() renders missing support as "NA" (text) / null (JSON).

Adds a support-free sample tree and integration tests for the monophyletic, not-monophyletic, and --json cases.