### PR TITLE
Raise combined test coverage to 92 percent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,11 @@ coverage.combined:
 	rm -rf output/
 	mkdir output/
 	python -m pytest --basetemp=output --cov=phykit --cov-branch --cov-append -m "integration" --cov-report=
-	python -m coverage report --precision=2
+	python -m coverage report --precision=2 --fail-under=91.5
 	python -m coverage json -o output/combined.coverage.json
 
 coverage.unit:
-	python -m pytest --cov=phykit --cov-branch --cov-fail-under=80 -m "not (integration or validation)" --cov-report=xml:unit.coverage.xml
+	python -m pytest --cov=phykit --cov-branch --cov-fail-under=90 -m "not (integration or validation)" --cov-report=xml:unit.coverage.xml
 
 coverage.integration:
 	rm -rf output/

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,16 @@ test.fast:
 # used by GitHub actions during CI workflow
 test.coverage: coverage.unit coverage.integration
 
+# Reproduce a local aggregate comparable across coverage-improvement commits.
+coverage.combined:
+	python -m coverage erase
+	python -m pytest --cov=phykit --cov-branch -m "not (integration or validation)" --cov-report=
+	rm -rf output/
+	mkdir output/
+	python -m pytest --basetemp=output --cov=phykit --cov-branch --cov-append -m "integration" --cov-report=
+	python -m coverage report --precision=2
+	python -m coverage json -o output/combined.coverage.json
+
 coverage.unit:
 	python -m pytest --cov=phykit --cov-branch --cov-fail-under=80 -m "not (integration or validation)" --cov-report=xml:unit.coverage.xml
 

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -109,6 +109,25 @@ The exact result has insufficient cross-version headroom for a 92% hard gate.
 CI therefore enforces 90% on the unit-only report and 91.5% on the merged
 Codecov project report. The local combined target also fails below 91.5%.
 
+## Codecov-accounting checkpoint
+
+- Date: 2026-07-17
+- Commit: `980f685b`
+- Unit tests: 6,126 passed, 869 deselected
+- Integration tests: 861 passed, 6,134 deselected
+- Statements: 45,582 of 48,110 covered (94.75%)
+- Branches: 15,305 of 17,244 covered (88.76%)
+- Partial branches: 1,531
+- Combined statement-plus-branch coverage: 93.16492%
+
+The additional batches target partially covered lines because Codecov treats
+those lines as uncovered in its merged report. They exercise plotting and
+color annotations, numerical fallbacks, malformed input handling, generic
+tree traversal, scalar simulation, and user-facing validation behavior. Since
+the baseline, the suite covers 2,826 additional statements and 1,550
+additional branches, increasing local combined coverage by 6.69 percentage
+points. All production modules remain at or above 80% local combined coverage.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -87,6 +87,28 @@ coverage batches. Since the baseline, the suite covers 2,090 additional
 statements and 1,151 additional branches, increasing combined coverage by
 4.96 percentage points.
 
+## Final checkpoint
+
+- Date: 2026-07-17
+- Commit: `dd8bb2e6`
+- Unit tests: 5,970 passed, 869 deselected
+- Integration tests: 861 passed, 5,978 deselected
+- Unit-only combined statement-plus-branch coverage: 90.81%
+- Statements: 45,087 of 48,110 covered (93.72%)
+- Branches: 15,042 of 17,244 covered (87.23%)
+- Partial branches: 1,670
+- Combined statement-plus-branch coverage: 92.00508%
+
+The final batches add shared plot configuration, hybridization, OU shift
+detection, and tip-to-tip node-distance coverage. Since the baseline, the suite
+covers 2,331 additional statements and 1,287 additional branches, increasing
+combined coverage by 5.54 percentage points. No production module remains
+below 80% coverage.
+
+The exact result has insufficient cross-version headroom for a 92% hard gate.
+CI therefore enforces 90% on the unit-only report and 91.5% on the merged
+Codecov project report. The local combined target also fails below 91.5%.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:
@@ -95,7 +117,8 @@ Run the complete unit and integration suites and create an aggregate report:
 make coverage.combined
 ```
 
-The target prints a two-decimal report, retains raw data in the ignored
-`.coverage` file, and writes machine-readable totals to the ignored
+The target prints a two-decimal report, fails below 91.5%, retains raw data in
+the ignored `.coverage` file, and writes machine-readable totals to the ignored
 `output/combined.coverage.json` file. The existing `make test.coverage` target
-continues to generate the separate XML reports uploaded by CI.
+continues to generate the separate XML reports uploaded by CI, with a 90%
+unit-only floor.

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -70,6 +70,23 @@ stochastic-character-map, and tree-space coverage batches. Since the baseline,
 the suite covers 1,660 additional statements and 869 additional branches,
 increasing combined coverage by 3.87 percentage points.
 
+## Fourth progress checkpoint
+
+- Date: 2026-07-17
+- Commit: `0e5c734f`
+- Unit tests: 5,898 passed, 867 deselected
+- Integration tests: 859 passed, 5,906 deselected
+- Statements: 44,846 of 48,110 covered (93.22%)
+- Branches: 14,906 of 17,244 covered (86.44%)
+- Partial branches: 1,734
+- Combined statement-plus-branch coverage: 91.43%
+
+This checkpoint adds tree-base, internal-branch-statistics, LTT,
+threshold-model, quartet-network, concordance-ASR, and rate-heterogeneity
+coverage batches. Since the baseline, the suite covers 2,090 additional
+statements and 1,151 additional branches, increasing combined coverage by
+4.96 percentage points.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -1,0 +1,37 @@
+# Coverage improvement baseline
+
+This document records the baseline for the effort to raise PhyKIT's combined
+coverage to approximately 92%. Coverage gains must come from behavioral tests;
+production modules must not be omitted and branch measurement must remain
+enabled.
+
+## Baseline
+
+- Date: 2026-07-17
+- Commit: `2c6b4d966dbf9f1facac755052872afd5c411bf9`
+- Python: 3.11.14
+- Unit tests: 5,322 passed, 867 deselected
+- Integration tests: 859 passed, 5,330 deselected
+- Statements: 42,756 of 48,108 covered (88.87%)
+- Branches: 13,755 of 17,244 covered (79.77%)
+- Partial branches: 2,299
+- Combined statement-plus-branch coverage: 86.47%
+- Codecov coverage for the same commit: 84.08%
+
+Codecov merges the unit and integration XML sessions and accounts for partial
+branch lines differently from Coverage.py's local aggregate. The branch target
+therefore needs local headroom above 92% before the Codecov target can be
+considered achieved.
+
+## Reproduction
+
+Run the complete unit and integration suites and create an aggregate report:
+
+```shell
+make coverage.combined
+```
+
+The target prints a two-decimal report, retains raw data in the ignored
+`.coverage` file, and writes machine-readable totals to the ignored
+`output/combined.coverage.json` file. The existing `make test.coverage` target
+continues to generate the separate XML reports uploaded by CI.

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -54,6 +54,22 @@ This checkpoint adds the OUwie and shared VCV utility coverage batches. Since
 the baseline, the suite covers 1,251 additional statements and 656 additional
 branches, increasing combined coverage by 2.92 percentage points.
 
+## Third progress checkpoint
+
+- Date: 2026-07-17
+- Commit: `2a0e5ebb`
+- Unit tests: 5,712 passed, 867 deselected
+- Integration tests: 859 passed, 5,720 deselected
+- Statements: 44,416 of 48,110 covered (92.32%)
+- Branches: 14,624 of 17,244 covered (84.81%)
+- Partial branches: 1,916
+- Combined statement-plus-branch coverage: 90.34%
+
+This checkpoint includes the discrete-model, independent-contrast, polytomy,
+stochastic-character-map, and tree-space coverage batches. Since the baseline,
+the suite covers 1,660 additional statements and 869 additional branches,
+increasing combined coverage by 3.87 percentage points.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -39,6 +39,21 @@ reconstruction coverage batches. Relative to the baseline, the suite covers
 950 additional statements and 497 additional branches while retaining the
 full branch-enabled unit and integration runs.
 
+## Second progress checkpoint
+
+- Date: 2026-07-17
+- Commit: `f7de88e6`
+- Unit tests: 5,597 passed, 867 deselected
+- Integration tests: 859 passed, 5,605 deselected
+- Statements: 44,007 of 48,110 covered (91.47%)
+- Branches: 14,411 of 17,244 covered (83.57%)
+- Partial branches: 2,017
+- Combined statement-plus-branch coverage: 89.39%
+
+This checkpoint adds the OUwie and shared VCV utility coverage batches. Since
+the baseline, the suite covers 1,251 additional statements and 656 additional
+branches, increasing combined coverage by 2.92 percentage points.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:

--- a/benchmarks/coverage.md
+++ b/benchmarks/coverage.md
@@ -23,6 +23,22 @@ branch lines differently from Coverage.py's local aggregate. The branch target
 therefore needs local headroom above 92% before the Codecov target can be
 considered achieved.
 
+## Progress checkpoint
+
+- Date: 2026-07-17
+- Commit: `f75ab4aa`
+- Unit tests: 5,520 passed, 867 deselected
+- Integration tests: 859 passed, 5,528 deselected
+- Statements: 43,706 of 48,110 covered (90.85%)
+- Branches: 14,252 of 17,244 covered (82.65%)
+- Partial branches: 2,094
+- Combined statement-plus-branch coverage: 88.68%
+
+This checkpoint includes focused helper, alignment, and ancestral
+reconstruction coverage batches. Relative to the baseline, the suite covers
+950 additional statements and 497 additional branches while retaining the
+full branch-enabled unit and integration runs.
+
 ## Reproduction
 
 Run the complete unit and integration suites and create an aggregate report:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,11 @@ coverage:
   precision: 2
   round: down
   range: "70...95"
+  status:
+    project:
+      default:
+        target: 91.5%
+        threshold: 0
 ignore:
   - "tests"
   - "phykit-runner.py"

--- a/phykit/services/alignment/pairwise_identity.py
+++ b/phykit/services/alignment/pairwise_identity.py
@@ -1023,7 +1023,7 @@ class PairwiseIdentity(Alignment):
                 if sys.stderr.isatty():
                     chunk_results = list(tqdm(
                         pool.imap(process_func, pair_chunks),
-                        total=len(pair_chunks),
+                        total=(n_pairs + chunk_size - 1) // chunk_size,
                         desc="Calculating pairwise identities",
                         unit="batch"
                     ))

--- a/phykit/services/alignment/phylo_gwas.py
+++ b/phykit/services/alignment/phylo_gwas.py
@@ -1050,6 +1050,8 @@ class PhyloGwas(Alignment):
         pheno_values = [phenotypes[t] for t in shared_taxa]
         pheno_type = self._detect_phenotype_type(pheno_values)
         is_continuous = pheno_type == "continuous"
+        unique_groups = []
+        group_counts = None
 
         if is_continuous:
             from scipy.special import stdtr

--- a/tests/integration/tree/test_hybridization_integration.py
+++ b/tests/integration/tree/test_hybridization_integration.py
@@ -98,6 +98,36 @@ class TestWithPlot:
         assert os.path.exists(output)
         assert os.path.getsize(output) > 0
 
+    @pytest.mark.parametrize("circular", [False, True])
+    def test_with_color_annotations(self, tmp_path, circular):
+        output = str(tmp_path / f"hybrid_colored_{circular}.png")
+        color_file = tmp_path / "colors.tsv"
+        color_file.write_text(
+            "bear\tlabel\t#ff0000\n"
+            "bear,raccoon\trange\t#ffe0e0\tUrsids\n"
+        )
+        from phykit.phykit import Phykit
+
+        sys.argv = [
+            "phykit",
+            "hybridization",
+            "-t",
+            TREE_SIMPLE,
+            "-g",
+            GENE_TREES,
+            "--plot",
+            output,
+            "--color-file",
+            str(color_file),
+        ]
+        if circular:
+            sys.argv.append("--circular")
+
+        Phykit()
+
+        assert os.path.exists(output)
+        assert os.path.getsize(output) > 0
+
 
 class TestWithAlphaArg:
     def test_with_alpha(self, capsys):

--- a/tests/unit/helpers/test_circular_layout.py
+++ b/tests/unit/helpers/test_circular_layout.py
@@ -108,6 +108,14 @@ def _fail_column_stack(*_args, **_kwargs):
     raise AssertionError("batched circular segments should be preallocated")
 
 
+class _PlotOnlyAxes:
+    def __init__(self):
+        self.plot_calls = []
+
+    def plot(self, *args, **kwargs):
+        self.plot_calls.append((args, kwargs))
+
+
 # Reusable simple tree: ((A:1,B:1):1,(C:1,D:1):1,(E:1,F:1):1);
 NEWICK_6 = "((A:1,B:1):1,(C:1,D:1):1,(E:1,F:1):1);"
 
@@ -181,6 +189,54 @@ class TestTipAngles:
         for clade_id, expected_coords in expected.items():
             for key, expected_value in expected_coords.items():
                 assert observed[clade_id][key] == pytest.approx(expected_value)
+
+    def test_legacy_tree_coordinate_fallback_matches_direct_layout(self):
+        source_tree = _make_tree("((A:1,B:1):1,C:2);")
+        parent_map = _build_parent_map(source_tree)
+        node_x = _build_node_x_phylogram(source_tree)
+        expected = compute_circular_coords(source_tree, node_x, parent_map)
+
+        class LegacyTree:
+            def __init__(self):
+                self.root_reads = 0
+
+            @property
+            def root(self):
+                self.root_reads += 1
+                if self.root_reads == 1:
+                    return object()
+                return source_tree.root
+
+            @staticmethod
+            def get_terminals():
+                return source_tree.get_terminals()
+
+            @staticmethod
+            def find_clades(order):
+                return source_tree.find_clades(order=order)
+
+        observed = compute_circular_coords(LegacyTree(), node_x, parent_map)
+
+        assert set(observed) == set(expected)
+        for clade_id, expected_coords in expected.items():
+            for key, expected_value in expected_coords.items():
+                assert observed[clade_id][key] == pytest.approx(expected_value)
+
+    def test_invalid_precomputed_clades_fall_back_to_direct_layout(self):
+        tree = _make_tree("((A:1,B:1):1,C:2);")
+        parent_map = _build_parent_map(tree)
+        node_x = _build_node_x_phylogram(tree)
+        expected = compute_circular_coords(tree, node_x, parent_map)
+
+        observed = compute_circular_coords(
+            tree,
+            node_x,
+            parent_map,
+            preorder_clades=list(tree.find_clades(order="preorder")),
+            terminal_clades=[],
+        )
+
+        assert observed == expected
 
 
 class TestInternalNodeAngles:
@@ -423,6 +479,38 @@ class TestDrawBranches:
 
         assert ax.plot_calls == len(parent_map) + internal_branch_count
 
+    def test_draw_branches_supports_legacy_tree_and_plot_only_axes(self):
+        source_tree = _make_tree("((A:1,B:1):1,C:1);")
+        parent_map = _build_parent_map(source_tree)
+        node_x = _build_node_x_phylogram(source_tree)
+        coords = compute_circular_coords(source_tree, node_x, parent_map)
+        legacy_root = object()
+        parent_map[id(source_tree.root)] = legacy_root
+        coords[id(legacy_root)] = {
+            "x": 0.0,
+            "y": 0.0,
+            "angle": 0.0,
+            "radius": 0.0,
+        }
+
+        class LegacyTree:
+            root = legacy_root
+
+            @staticmethod
+            def find_clades(order):
+                assert order == "preorder"
+                return source_tree.find_clades(order=order)
+
+        ax = _PlotOnlyAxes()
+        draw_circular_branches(ax, LegacyTree(), coords, parent_map)
+
+        clade_count = len(list(source_tree.find_clades()))
+        internal_count = len(source_tree.get_nonterminals())
+        assert len(ax.plot_calls) == clade_count + internal_count
+        root_segment = ax.plot_calls[0][0]
+        assert root_segment[0] == [0.0, 0.0]
+        assert root_segment[1] == [0.0, 0.0]
+
     def test_draw_tip_labels_no_error(self):
         tree = _make_tree(NEWICK_6)
         parent_map = _build_parent_map(tree)
@@ -567,6 +655,24 @@ class TestDrawBranches:
         assert len(line_collections[0].get_segments()) == 2
         plt.close(fig)
 
+    def test_draw_colored_arcs_supports_plot_only_axes_and_empty_input(self):
+        ax = _PlotOnlyAxes()
+        draw_circular_colored_arcs(ax, [])
+        assert ax.plot_calls == []
+
+        draw_circular_colored_arcs(
+            ax,
+            [
+                (0.0, 0.0, 1.0, 0.0, math.pi / 2, "blue"),
+                (1.0, -1.0, 2.0, 0.0, 3.0 * math.pi / 2, "red"),
+            ],
+            lw=2.0,
+        )
+
+        assert len(ax.plot_calls) == 2
+        assert [call[1]["color"] for call in ax.plot_calls] == ["blue", "red"]
+        assert all(call[1]["linewidth"] == 2.0 for call in ax.plot_calls)
+
     def test_draw_scalar_arcs_batches_real_axes(self, monkeypatch):
         import matplotlib.axes
         from matplotlib.collections import LineCollection
@@ -604,6 +710,25 @@ class TestDrawBranches:
         assert len(line_collections[0].get_segments()) == 2
         assert list(line_collections[0].get_array()) == [0.25, 0.75]
         plt.close(fig)
+
+    def test_draw_scalar_arcs_supports_plot_only_axes_and_empty_input(self):
+        from matplotlib.colors import Normalize
+
+        ax = _PlotOnlyAxes()
+        cmap = plt.get_cmap("viridis")
+        norm = Normalize(vmin=0.0, vmax=1.0)
+        draw_circular_scalar_arcs(ax, [], cmap, norm)
+        assert ax.plot_calls == []
+
+        draw_circular_scalar_arcs(
+            ax,
+            [(0.0, 0.0, 1.0, 0.0, math.pi / 2, 0.25)],
+            cmap,
+            norm,
+        )
+
+        assert len(ax.plot_calls) == 1
+        assert ax.plot_calls[0][1]["color"] == cmap(0.25)
 
     def test_draw_gradient_branch_no_error(self):
         import matplotlib.cm as cm
@@ -643,6 +768,33 @@ class TestDrawBranches:
 
         assert len(line_collections) == 1
         plt.close(fig)
+
+    def test_draw_gradient_branch_supports_plot_only_axes_and_constant_range(self):
+        colors = []
+
+        def cmap(value):
+            colors.append(value)
+            return (value, value, value, 1.0)
+
+        ax = _PlotOnlyAxes()
+        draw_circular_gradient_branch(
+            ax,
+            {"angle": 0.0, "radius": 1.0},
+            {"angle": 0.0, "radius": 3.0},
+            cmap,
+            2.0,
+            2.0,
+            1.0,
+            4.0,
+            lw=2.5,
+        )
+
+        assert len(ax.plot_calls) == 30
+        assert len(colors) == 30
+        assert colors[0] == 0.0
+        assert colors[-1] == 1.0
+        assert ax.plot_calls[0][0][0][0] == pytest.approx(1.0)
+        assert ax.plot_calls[-1][0][0][1] == pytest.approx(3.0)
 
     def test_draw_gradient_branches_batches_all_branches_real_axes(self, monkeypatch):
         import matplotlib.axes
@@ -688,6 +840,35 @@ class TestDrawBranches:
         assert len(line_collections[0].get_segments()) == 60
         plt.close(fig)
 
+    def test_draw_gradient_branches_supports_plot_only_axes_and_empty_input(self):
+        ax = _PlotOnlyAxes()
+        cmap = lambda value: (value, value, value, 1.0)
+        draw_circular_gradient_branches(ax, [], cmap, 0.0, 1.0)
+        assert ax.plot_calls == []
+
+        draw_circular_gradient_branches(
+            ax,
+            [
+                (
+                    {"angle": 0.0, "radius": 0.0},
+                    {"angle": 0.0, "radius": 1.0},
+                    -1.0,
+                    2.0,
+                ),
+                (
+                    {"angle": math.pi / 2, "radius": 1.0},
+                    {"angle": math.pi / 2, "radius": 2.0},
+                    0.25,
+                    0.75,
+                ),
+            ],
+            cmap,
+            0.0,
+            1.0,
+        )
+
+        assert len(ax.plot_calls) == 60
+
     def test_draw_multi_segment_branch_no_error(self):
         pc = {"angle": 1.0, "radius": 0.5}
         cc = {"angle": 1.0, "radius": 2.5}
@@ -726,3 +907,19 @@ class TestDrawBranches:
 
         assert len(line_collections) == 1
         plt.close(fig)
+
+    def test_draw_multi_segment_branch_supports_plot_only_axes(self):
+        ax = _PlotOnlyAxes()
+        draw_circular_multi_segment_branch(
+            ax,
+            {"angle": math.pi, "radius": 1.0},
+            {"angle": math.pi, "radius": 3.0},
+            [(0.0, 0.25, "A"), (0.25, 1.0, "B")],
+            {"A": "red", "B": "blue"},
+            lw=3.0,
+        )
+
+        assert len(ax.plot_calls) == 2
+        assert [call[1]["color"] for call in ax.plot_calls] == ["red", "blue"]
+        assert ax.plot_calls[0][0][0] == pytest.approx([-1.0, -1.5])
+        assert ax.plot_calls[1][0][0] == pytest.approx([-1.5, -3.0])

--- a/tests/unit/helpers/test_discrete_models.py
+++ b/tests/unit/helpers/test_discrete_models.py
@@ -268,6 +268,106 @@ class TestMatrixExp:
         Q = build_q_matrix(np.array([0.0]), 2, "ER")
         np.testing.assert_array_equal(matrix_exp(Q, 10.0), np.eye(2))
 
+    def test_matrix_shape_and_rate_validation_rejects_invalid_inputs(self):
+        import phykit.helpers.discrete_models as discrete_models
+
+        assert discrete_models._is_exact_symmetric_matrix(np.zeros((2, 3))) is False
+        assert discrete_models._is_exact_symmetric_matrix(object()) is False
+        assert discrete_models._two_state_ctmc_rates(object()) is None
+        assert (
+            discrete_models._two_state_ctmc_rates(
+                np.array([[-1.0, -1.0], [1.0, -1.0]])
+            )
+            is None
+        )
+        assert (
+            discrete_models._two_state_ctmc_rates(
+                np.array([[-2.0, 1.0], [1.0, -1.0]])
+            )
+            is None
+        )
+
+    def test_q_matrix_index_helpers_reuse_cached_indices(self):
+        import phykit.helpers.discrete_models as discrete_models
+
+        discrete_models._SYM_INDEX_CACHE.clear()
+        discrete_models._ARD_MASK_CACHE.clear()
+
+        sym_indices = discrete_models._sym_offdiag_indices(4)
+        ard_mask = discrete_models._ard_offdiag_mask(4)
+
+        assert discrete_models._sym_offdiag_indices(4) is sym_indices
+        assert discrete_models._ard_offdiag_mask(4) is ard_mask
+
+    def test_symmetric_eigendecomposition_rejects_nonfinite_result(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        monkeypatch.setattr(
+            discrete_models.np.linalg,
+            "eigh",
+            lambda _matrix: (np.array([np.nan]), np.eye(1)),
+        )
+
+        assert discrete_models._matrix_exp_eigendecomp_context(np.eye(3)) is None
+
+    def test_symmetric_eigendecomposition_failure_returns_none(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        def fail_eigh(_matrix):
+            raise np.linalg.LinAlgError("eigendecomposition failed")
+
+        monkeypatch.setattr(discrete_models.np.linalg, "eigh", fail_eigh)
+
+        assert discrete_models._matrix_exp_eigendecomp_context(np.eye(3)) is None
+
+    def test_generic_eigendecomposition_rejects_complex_inverse(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        matrix = np.array(
+            [[-1.0, 1.0, 0.0], [0.0, -1.0, 1.0], [1.0, 0.0, -1.0]]
+        )
+        monkeypatch.setattr(
+            discrete_models.np.linalg,
+            "eig",
+            lambda _matrix: (np.array([0.0, -1.0, -2.0]), np.eye(3)),
+        )
+        monkeypatch.setattr(
+            discrete_models.np.linalg,
+            "inv",
+            lambda _matrix: np.eye(3, dtype=complex),
+        )
+
+        assert discrete_models._matrix_exp_eigendecomp_context(matrix) is None
+
+    def test_generic_eigendecomposition_failure_returns_none(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        matrix = np.array(
+            [[-1.0, 1.0, 0.0], [0.0, -1.0, 1.0], [1.0, 0.0, -1.0]]
+        )
+
+        def fail_eig(_matrix):
+            raise ValueError("eigendecomposition failed")
+
+        monkeypatch.setattr(discrete_models.np.linalg, "eig", fail_eig)
+
+        assert discrete_models._matrix_exp_eigendecomp_context(matrix) is None
+
+    def test_generic_eigendecomposition_rejects_nonfinite_result(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        matrix = np.array(
+            [[-1.0, 1.0, 0.0], [0.0, -1.0, 1.0], [1.0, 0.0, -1.0]]
+        )
+        monkeypatch.setattr(
+            discrete_models.np.linalg,
+            "eig",
+            lambda _matrix: (np.array([np.nan, -1.0, -2.0]), np.eye(3)),
+        )
+        monkeypatch.setattr(discrete_models.np.linalg, "inv", lambda _matrix: np.eye(3))
+
+        assert discrete_models._matrix_exp_eigendecomp_context(matrix) is None
+
     def test_rows_sum_to_one(self):
         Q = build_q_matrix(np.array([0.5]), 3, "ER")
         P = matrix_exp(Q, 1.0)
@@ -413,6 +513,216 @@ class TestFelsensteinPruning:
         pi = np.ones(2) / 2.0
         _, loglik = felsenstein_pruning(tree_simple, tip_states, Q, pi, states)
         assert loglik < 0
+
+    def test_legacy_postorder_fallback_matches_direct_traversal(
+        self, tree_simple, monkeypatch
+    ):
+        import phykit.helpers.discrete_models as discrete_models
+
+        states = ["0", "1"]
+        tip_states = {
+            tip.name: states[index % 2]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        Q = build_q_matrix(np.array([0.5]), 2, "ER")
+        pi = np.array([0.5, 0.5])
+        expected = felsenstein_pruning(tree_simple, tip_states, Q, pi, states)[1]
+        monkeypatch.setattr(
+            discrete_models,
+            "_postorder_clades_direct",
+            lambda _tree: None,
+        )
+
+        observed = felsenstein_pruning(tree_simple, tip_states, Q, pi, states)[1]
+
+        assert observed == pytest.approx(expected)
+
+    def test_eigendecomposition_transition_failure_uses_matrix_exp(
+        self, tree_simple, monkeypatch
+    ):
+        import phykit.helpers.discrete_models as discrete_models
+
+        states = ["0", "1", "2"]
+        tip_states = {
+            tip.name: states[index % 3]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        Q = build_q_matrix(np.array([0.2]), 3, "ER")
+        pi = np.ones(3) / 3.0
+        calls = 0
+        real_matrix_exp = discrete_models.matrix_exp
+
+        def counting_matrix_exp(matrix, branch_length):
+            nonlocal calls
+            calls += 1
+            return real_matrix_exp(matrix, branch_length)
+
+        monkeypatch.setattr(
+            discrete_models,
+            "_matrix_exp_from_eigendecomp",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(discrete_models, "matrix_exp", counting_matrix_exp)
+
+        _, loglik = felsenstein_pruning(tree_simple, tip_states, Q, pi, states)
+
+        assert calls > 0
+        assert np.isfinite(loglik)
+
+    def test_pruning_returns_floor_for_impossible_root_likelihood(self, tree_simple):
+        Q = build_q_matrix(np.array([0.5]), 2, "ER")
+
+        _, loglik = felsenstein_pruning(
+            tree_simple,
+            {},
+            Q,
+            np.array([0.5, 0.5]),
+            ["0", "1"],
+        )
+
+        assert loglik == -1e20
+
+    def test_prepared_legacy_context_matches_indexed_context(self, tree_simple):
+        states = ["0", "1"]
+        tip_states = {
+            tip.name: states[index % 2]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        Q = build_q_matrix(np.array([0.5]), 2, "ER")
+        pi = np.array([0.5, 0.5])
+        expected = _felsenstein_loglik_prepared(context, Q, pi)
+        legacy_context = context.copy()
+        for key in (
+            "tip_liks",
+            "internal_entries",
+            "internal_entries_by_length_index",
+            "unique_branch_lengths",
+        ):
+            legacy_context.pop(key)
+
+        observed = _felsenstein_loglik_prepared(legacy_context, Q, pi)
+
+        assert observed == pytest.approx(expected)
+
+    def test_prepared_zero_rate_uses_identity_transitions(self, tree_simple):
+        states = ["0", "1"]
+        tip_states = {tip.name: "0" for tip in tree_simple.get_terminals()}
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        context.pop("internal_entries_by_length_index")
+        context.pop("unique_branch_lengths")
+        Q = build_q_matrix(np.array([0.0]), 2, "ER")
+
+        observed = _felsenstein_loglik_prepared(
+            context, Q, np.array([0.5, 0.5])
+        )
+
+        assert observed == pytest.approx(math.log(0.5))
+
+    @pytest.mark.parametrize("state_count", [2, 3])
+    def test_prepared_likelihood_returns_floor_for_zero_tip_likelihoods(
+        self, tree_simple, state_count
+    ):
+        states = [str(index) for index in range(state_count)]
+        tip_states = {
+            tip.name: states[index % state_count]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        context["tip_liks"] = np.zeros_like(context["tip_liks"])
+        Q = build_q_matrix(np.array([0.5]), state_count, "ER")
+
+        observed = _felsenstein_loglik_prepared(
+            context,
+            Q,
+            np.ones(state_count) / state_count,
+        )
+
+        assert observed == -1e20
+
+    def test_two_state_er_rate_legacy_context_delegates_to_prepared_likelihood(
+        self, tree_simple
+    ):
+        import phykit.helpers.discrete_models as discrete_models
+
+        states = ["0", "1"]
+        tip_states = {
+            tip.name: states[index % 2]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        pi = np.array([0.5, 0.5])
+        expected = discrete_models._felsenstein_loglik_two_state_er_rate(
+            context, 0.5, pi
+        )
+        legacy_context = context.copy()
+        legacy_context.pop("tip_liks")
+        legacy_context.pop("internal_entries")
+
+        observed = discrete_models._felsenstein_loglik_two_state_er_rate(
+            legacy_context, 0.5, pi
+        )
+
+        assert observed == pytest.approx(expected)
+
+    @pytest.mark.parametrize("state_count", [2, 3, 4, 5])
+    def test_er_rate_returns_floor_for_zero_tip_likelihoods(
+        self, tree_simple, state_count
+    ):
+        states = [str(index) for index in range(state_count)]
+        tip_states = {
+            tip.name: states[index % state_count]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        context["tip_liks"] = np.zeros_like(context["tip_liks"])
+
+        observed = _felsenstein_loglik_er_rate(
+            context,
+            0.5,
+            np.ones(state_count) / state_count,
+        )
+
+        assert observed == -1e20
+
+    @pytest.mark.parametrize("state_count", [3, 4])
+    def test_er_rate_nonindexed_context_matches_indexed_context(
+        self, tree_simple, state_count
+    ):
+        states = [str(index) for index in range(state_count)]
+        tip_states = {
+            tip.name: states[index % state_count]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        pi = np.ones(state_count) / state_count
+        expected = _felsenstein_loglik_er_rate(context, 0.5, pi)
+        nonindexed_context = context.copy()
+        nonindexed_context.pop("internal_entries_by_length_index")
+        nonindexed_context.pop("unique_branch_lengths")
+
+        observed = _felsenstein_loglik_er_rate(nonindexed_context, 0.5, pi)
+
+        assert observed == pytest.approx(expected)
+
+    def test_er_rate_legacy_context_delegates_to_prepared_likelihood(
+        self, tree_simple
+    ):
+        states = ["0", "1", "2"]
+        tip_states = {
+            tip.name: states[index % 3]
+            for index, tip in enumerate(tree_simple.get_terminals())
+        }
+        context = _prepare_felsenstein_context(tree_simple, tip_states, states)
+        pi = np.ones(3) / 3.0
+        expected = _felsenstein_loglik_er_rate(context, 0.5, pi)
+        legacy_context = context.copy()
+        legacy_context.pop("tip_liks")
+        legacy_context.pop("internal_entries")
+
+        observed = _felsenstein_loglik_er_rate(legacy_context, 0.5, pi)
+
+        assert observed == pytest.approx(expected)
 
     def test_perfect_data_high_loglik(self, tree_simple):
         """All tips same state should give high likelihood."""

--- a/tests/unit/helpers/test_discrete_models.py
+++ b/tests/unit/helpers/test_discrete_models.py
@@ -1591,8 +1591,199 @@ class TestFelsensteinPruning:
         assert loglik2 == loglik1
         discrete_models._FIT_Q_MATRIX_CACHE.clear()
 
+    def test_fit_q_matrix_recovers_when_optimizers_reject_inputs(self, monkeypatch):
+        from Bio.Phylo.Newick import Clade, Tree
+        import phykit.helpers.discrete_models as discrete_models
+
+        tree = Tree(
+            root=Clade(
+                clades=[
+                    Clade(branch_length=1.0, name="A"),
+                    Clade(branch_length=1.0, name="B"),
+                    Clade(branch_length=1.0, name="C"),
+                ],
+            )
+        )
+        context = _prepare_felsenstein_context(
+            tree,
+            {"A": "0", "B": "1", "C": "2"},
+            ["0", "1", "2"],
+        )
+        context["fit_q_matrix_cache_key"] = None
+
+        def reject_optimization(*_args, **_kwargs):
+            raise ValueError("optimizer rejected input")
+
+        monkeypatch.setattr(discrete_models, "minimize", reject_optimization)
+
+        Q, loglik = fit_q_matrix(
+            tree,
+            {"A": "0", "B": "1", "C": "2"},
+            ["0", "1", "2"],
+            "SYM",
+            pruning_context=context,
+        )
+
+        assert Q.shape == (3, 3)
+        assert np.isfinite(loglik)
+
+    def test_fit_q_matrix_cache_evicts_oldest_entry(self, monkeypatch):
+        import phykit.helpers.discrete_models as discrete_models
+
+        discrete_models._FIT_Q_MATRIX_CACHE.clear()
+        monkeypatch.setattr(discrete_models, "_FIT_Q_MATRIX_CACHE_MAXSIZE", 2)
+        Q = np.eye(2)
+
+        discrete_models._cache_fit_q_matrix_result("first", Q, -1.0)
+        discrete_models._cache_fit_q_matrix_result("second", Q, -2.0)
+        discrete_models._cache_fit_q_matrix_result("third", Q, -3.0)
+
+        assert "first" not in discrete_models._FIT_Q_MATRIX_CACHE
+        assert set(discrete_models._FIT_Q_MATRIX_CACHE) == {"second", "third"}
+        discrete_models._FIT_Q_MATRIX_CACHE.clear()
+
 
 class TestParseDiscreteTraits:
+    def test_legacy_multi_column_parser_returns_selected_trait(self):
+        import phykit.helpers.discrete_models as discrete_models
+
+        result = discrete_models._parse_multi_column(
+            [
+                "taxon\tdiet\thabitat",
+                "A\tcarnivore\tforest",
+                "B\therbivore\tplains",
+                "C\tomnivore\twetland",
+            ],
+            "traits.tsv",
+            ["A", "B", "C"],
+            "diet",
+        )
+
+        assert result == {
+            "A": "carnivore",
+            "B": "herbivore",
+            "C": "omnivore",
+        }
+
+    @pytest.mark.parametrize(
+        ("data_lines", "trait_column", "expected_message"),
+        [
+            (
+                ["taxon\tdiet"],
+                "diet",
+                "Trait file must have a header row and at least one data row.",
+            ),
+            (
+                ["taxon", "A"],
+                "diet",
+                "Header must have at least 2 columns (taxon + at least 1 trait).",
+            ),
+            (
+                ["taxon\tdiet", "A\tcarnivore"],
+                "habitat",
+                "Column 'habitat' not found in trait file.",
+            ),
+            (
+                ["taxon\tdiet\thabitat", "A\tcarnivore"],
+                "diet",
+                "Line 2 has 2 columns; expected 3.",
+            ),
+            (
+                ["taxon\tdiet", "A\t"],
+                "diet",
+                "Missing trait value for taxon 'A' on line 2.",
+            ),
+        ],
+    )
+    def test_legacy_multi_column_parser_reports_invalid_input(
+        self, data_lines, trait_column, expected_message
+    ):
+        import phykit.helpers.discrete_models as discrete_models
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            discrete_models._parse_multi_column(
+                data_lines,
+                "traits.tsv",
+                ["A", "B", "C"],
+                trait_column,
+            )
+
+        assert expected_message in excinfo.value.messages
+
+    def test_legacy_two_column_parser_returns_traits(self):
+        import phykit.helpers.discrete_models as discrete_models
+
+        result = discrete_models._parse_two_column(
+            ["A\tcarnivore", "B\therbivore", "C\tomnivore"],
+            "traits.tsv",
+            ["A", "B", "C"],
+        )
+
+        assert result == {
+            "A": "carnivore",
+            "B": "herbivore",
+            "C": "omnivore",
+        }
+
+    @pytest.mark.parametrize(
+        ("line", "column_count"),
+        [("A", 1), ("A\tcarnivore\textra", 3)],
+    )
+    def test_legacy_two_column_parser_rejects_malformed_rows(
+        self, line, column_count
+    ):
+        import phykit.helpers.discrete_models as discrete_models
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            discrete_models._parse_two_column(
+                [line],
+                "traits.tsv",
+                ["A", "B", "C"],
+            )
+
+        assert (
+            f"Line 1 has {column_count} columns; expected 2 (taxon, state)."
+            in excinfo.value.messages
+        )
+
+    def test_shared_taxa_validation_accepts_reordered_equal_sets(self, capsys):
+        import phykit.helpers.discrete_models as discrete_models
+
+        traits = {"A": "0", "B": "1", "C": "0"}
+
+        observed = discrete_models._validate_shared_taxa(
+            traits, ["C", "B", "A"]
+        )
+
+        assert observed is traits
+        assert capsys.readouterr().err == ""
+
+    def test_shared_taxa_validation_warns_for_both_unmatched_sets(self, capsys):
+        import phykit.helpers.discrete_models as discrete_models
+
+        observed = discrete_models._validate_shared_taxa(
+            {"A": "0", "B": "1", "C": "0", "D": "1"},
+            ["A", "B", "C", "E"],
+        )
+
+        assert observed == {"A": "0", "B": "1", "C": "0"}
+        warnings = capsys.readouterr().err
+        assert "1 taxa in tree but not in trait file: E" in warnings
+        assert "1 taxa in trait file but not in tree: D" in warnings
+
+    def test_parse_multi_column_reports_missing_selected_column(self, tmp_path):
+        path = tmp_path / "traits.tsv"
+        path.write_text("taxon\tdiet\nA\tcarnivore\nB\therbivore\nC\tomnivore\n")
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            parse_discrete_traits(
+                str(path),
+                ["A", "B", "C"],
+                trait_column="habitat",
+            )
+
+        assert "Column 'habitat' not found in trait file." in excinfo.value.messages
+
     def test_parse_multi_column(self, tmp_path):
         f = tmp_path / "traits.tsv"
         f.write_text("taxon\tdiet\nA\tcarnivore\nB\therbivore\nC\tomnivore\n")

--- a/tests/unit/helpers/test_discrete_models.py
+++ b/tests/unit/helpers/test_discrete_models.py
@@ -264,6 +264,10 @@ class TestMatrixExp:
         P = matrix_exp(Q, 0.0)
         assert np.allclose(P, np.eye(2))
 
+    def test_zero_rate_two_state_matrix_is_identity_for_positive_time(self):
+        Q = build_q_matrix(np.array([0.0]), 2, "ER")
+        np.testing.assert_array_equal(matrix_exp(Q, 10.0), np.eye(2))
+
     def test_rows_sum_to_one(self):
         Q = build_q_matrix(np.array([0.5]), 3, "ER")
         P = matrix_exp(Q, 1.0)
@@ -1046,6 +1050,61 @@ class TestFelsensteinPruning:
             pi,
         ) == pytest.approx(expected)
 
+    @pytest.mark.parametrize("indexed_lengths", [True, False])
+    def test_five_state_er_rate_matches_general_q_likelihood(
+        self,
+        indexed_lengths,
+    ):
+        from Bio.Phylo.Newick import Clade, Tree
+
+        states = [str(index) for index in range(5)]
+        tree = Tree(
+            root=Clade(
+                clades=[
+                    Clade(branch_length=0.5, name=f"T{index}")
+                    for index in range(5)
+                ]
+            )
+        )
+        tip_states = {f"T{index}": state for index, state in enumerate(states)}
+        context = _prepare_felsenstein_context(tree, tip_states, states)
+        rate = 0.13
+        pi = np.ones(5) / 5.0
+        Q = build_q_matrix(np.array([rate]), 5, "ER")
+
+        if not indexed_lengths:
+            context.pop("internal_entries_by_length_index")
+            context.pop("unique_branch_lengths")
+
+        expected = _felsenstein_loglik_prepared(context, Q, pi)
+        observed = _felsenstein_loglik_er_rate(context, rate, pi)
+
+        assert observed == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+    def test_five_state_er_rate_returns_floor_for_zero_root_probability(self):
+        from Bio.Phylo.Newick import Clade, Tree
+
+        states = [str(index) for index in range(5)]
+        tree = Tree(
+            root=Clade(
+                clades=[
+                    Clade(branch_length=1.0, name=f"T{index}")
+                    for index in range(5)
+                ]
+            )
+        )
+        context = _prepare_felsenstein_context(
+            tree,
+            {f"T{index}": state for index, state in enumerate(states)},
+            states,
+        )
+
+        assert _felsenstein_loglik_er_rate(
+            context,
+            0.2,
+            np.zeros(5),
+        ) == -1e20
+
     def test_two_state_er_fit_avoids_objective_q_rebuilds(self, monkeypatch):
         from Bio.Phylo.Newick import Clade, Tree
         import phykit.helpers.discrete_models as discrete_models
@@ -1328,6 +1387,45 @@ class TestParseDiscreteTraits:
             parse_discrete_traits(str(f), ["A", "B", "C"], trait_column="diet")
 
         assert "Line 3 has 5 columns; expected 4." in excinfo.value.messages
+
+    @pytest.mark.parametrize(
+        ("content", "expected_message"),
+        [
+            (
+                "taxon\nA\n",
+                "Header must have at least 2 columns (taxon + at least 1 trait).",
+            ),
+            (
+                "taxon\tdiet\thabitat\nA\t\tforest\nB\therbivore\tplain\n",
+                "Missing trait value for taxon 'A' on line 2.",
+            ),
+            (
+                "taxon\tdiet\n",
+                "Trait file must have a header row and at least one data row.",
+            ),
+            (
+                "# comments only\n\n",
+                "Trait file must have a header row and at least one data row.",
+            ),
+        ],
+    )
+    def test_parse_multi_column_reports_malformed_streams(
+        self,
+        tmp_path,
+        content,
+        expected_message,
+    ):
+        path = tmp_path / "traits.tsv"
+        path.write_text(content)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            parse_discrete_traits(
+                str(path),
+                ["A", "B", "C"],
+                trait_column="diet",
+            )
+
+        assert expected_message in excinfo.value.messages
 
     def test_parse_two_column(self, tmp_path):
         f = tmp_path / "traits.tsv"

--- a/tests/unit/helpers/test_parsimony_utils.py
+++ b/tests/unit/helpers/test_parsimony_utils.py
@@ -46,6 +46,16 @@ def _make_tree(newick):
     return Phylo.read(StringIO(newick), "newick")
 
 
+def _make_balanced_tree(tip_names):
+    def build(names):
+        if len(names) == 1:
+            return f"{names[0]}:1"
+        midpoint = len(names) // 2
+        return f"({build(names[:midpoint])},{build(names[midpoint:])}):1"
+
+    return _make_tree(f"{build(tip_names)};")
+
+
 # ---------------------------------------------------------------------------
 # build_parent_map
 # ---------------------------------------------------------------------------
@@ -647,6 +657,46 @@ class TestFitchDownpass:
             {"A", "G", "T"},
             {"T"},
         ]
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            "all_large",
+            "all_large_cached",
+            "mixed",
+            "mixed_cached",
+        ],
+    )
+    def test_bitmask_state_conversion_matches_generic_fitch(self, mode, monkeypatch):
+        cached = mode.endswith("cached")
+        mixed = mode.startswith("mixed")
+        tip_count = 28 if cached else 8
+        character_count = 16 if cached else (2 if mixed else 1)
+        tip_names = [f"T{index}" for index in range(tip_count)]
+        tree = _make_balanced_tree(tip_names)
+        tip_states = {}
+
+        for index, name in enumerate(tip_names):
+            pattern = index % 7 if cached else index
+            states = []
+            for character in range(character_count):
+                if mixed and character % 2 == 0:
+                    states.append(str(pattern % 2))
+                else:
+                    states.append(f"S{pattern}")
+            tip_states[name] = states
+
+        optimized_sets, optimized_scores = fitch_downpass(tree, tip_states)
+
+        monkeypatch.setattr(
+            parsimony_module,
+            "_postorder_clades_direct",
+            lambda _tree: None,
+        )
+        generic_sets, generic_scores = fitch_downpass(tree, tip_states)
+
+        assert optimized_scores == generic_scores
+        assert optimized_sets == generic_sets
 
     def test_polytomy_tree_after_resolve(self):
         """Works on a resolved polytomy tree."""

--- a/tests/unit/helpers/test_parsimony_utils.py
+++ b/tests/unit/helpers/test_parsimony_utils.py
@@ -121,6 +121,57 @@ class TestBuildParentMap:
         assert pm[id(trifurcation.clades[1])] is trifurcation
         assert pm[id(trifurcation.clades[2])] is trifurcation
 
+    def test_legacy_tree_falls_back_to_find_clades(self):
+        source_tree = _make_tree("((A:1,B:1):1,C:1);")
+        clades = list(source_tree.find_clades(order="preorder"))
+
+        class LegacyTree:
+            root = object()
+
+            @staticmethod
+            def find_clades(order):
+                assert order == "preorder"
+                return clades
+
+        parent_map = build_parent_map(LegacyTree())
+
+        assert len(parent_map) == len(clades) - 1
+        assert parent_map[id(source_tree.root.clades[0])] is source_tree.root
+
+    @pytest.mark.parametrize(
+        "helper",
+        [
+            parsimony_module._build_parent_map_direct,
+            parsimony_module._preorder_clades_direct,
+            parsimony_module._postorder_clades_direct,
+        ],
+    )
+    def test_direct_traversal_helpers_reject_legacy_roots(self, helper):
+        class LegacyTree:
+            root = object()
+
+        assert helper(LegacyTree()) is None
+
+    @pytest.mark.parametrize(
+        "helper",
+        [
+            parsimony_module._build_parent_map_direct,
+            parsimony_module._preorder_clades_direct,
+            parsimony_module._postorder_clades_direct,
+        ],
+    )
+    def test_direct_traversal_helpers_reject_legacy_children(self, helper):
+        from Bio.Phylo.BaseTree import Clade, Tree
+
+        class LegacyChild:
+            @property
+            def clades(self):
+                raise AttributeError("legacy child")
+
+        tree = Tree(root=Clade(clades=[LegacyChild()]))
+
+        assert helper(tree) is None
+
 
 # ---------------------------------------------------------------------------
 # resolve_polytomies
@@ -230,6 +281,28 @@ class TestResolvePolytomies:
         Phylo.write(expected, expected_out, "newick")
         Phylo.write(actual, actual_out, "newick")
         assert actual_out.getvalue() == expected_out.getvalue()
+
+    def test_legacy_tree_resolves_polytomy_through_find_clades(self):
+        source_tree = _make_tree("(A:1,B:1,C:1,D:1);")
+        clades = list(source_tree.find_clades(order="postorder"))
+
+        class LegacyTree:
+            root = object()
+
+            @staticmethod
+            def find_clades(order):
+                assert order == "postorder"
+                return clades
+
+        resolve_polytomies(LegacyTree())
+
+        assert all(len(clade.clades) <= 2 for clade in clades)
+        assert sorted(tip.name for tip in source_tree.get_terminals()) == [
+            "A",
+            "B",
+            "C",
+            "D",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -657,6 +730,42 @@ class TestFitchDownpass:
             {"A", "G", "T"},
             {"T"},
         ]
+
+    @pytest.mark.parametrize(
+        ("tip_states", "expected_root", "expected_score"),
+        [
+            ({"A": ["?"], "B": ["-"], "C": ["?"]}, set(), 0),
+            ({"A": ["0"], "B": ["?"], "C": ["0"]}, {"0"}, 0),
+            ({"A": ["0"], "B": ["1"], "C": ["2"]}, {"0", "1", "2"}, 1),
+        ],
+    )
+    def test_unresolved_multifurcation_uses_generic_fitch_semantics(
+        self,
+        tip_states,
+        expected_root,
+        expected_score,
+    ):
+        tree = _make_tree("(A:1,B:1,C:1);")
+
+        node_state_sets, scores = fitch_downpass(tree, tip_states)
+
+        assert node_state_sets[id(tree.root)] == [expected_root]
+        assert scores == [expected_score]
+
+    def test_unary_tree_inherits_its_child_state(self):
+        from Bio.Phylo.BaseTree import Clade, Tree
+
+        tip = Clade(name="A")
+        tree = Tree(root=Clade(name="root", clades=[tip]))
+
+        node_state_sets, scores = fitch_downpass(tree, {"A": ["present"]})
+
+        assert scores == [0]
+        assert node_state_sets[id(tree.root)] == [{"present"}]
+
+    def test_large_mask_lookup_declines_unsupported_state_count(self):
+        states = tuple(f"S{index}" for index in range(7))
+        assert parsimony_module._build_small_mask_set_lookup(states) is None
 
     @pytest.mark.parametrize(
         "mode",
@@ -1393,6 +1502,60 @@ class TestRetentionIndex:
 
         assert ri_per_char == [1.0, 0.0]
         assert ri_overall == pytest.approx(0.5)
+
+    def test_empty_matrix_has_no_retention_index(self):
+        assert retention_index([], []) == ([], None)
+
+    def test_large_ascii_matrix_uses_vectorized_retention_index(self):
+        informative = ["0", "0", "1", "1"] * 16
+        constant = ["0"] * 64
+        missing = ["?", "-"] * 32
+        columns = [informative] * 32 + [constant] * 16 + [missing] * 16
+        observed = [1] * 32 + [0] * 32
+
+        ri_per_char, ri_overall = retention_index(columns, observed)
+
+        assert ri_per_char[:32] == [1.0] * 32
+        assert ri_per_char[32:] == [None] * 32
+        assert ri_overall == 1.0
+
+    def test_large_all_missing_matrix_has_no_retention_index(self):
+        columns = [["?", "-"] * 32 for _ in range(64)]
+
+        ri_per_char, ri_overall = retention_index(columns, [0] * 64)
+
+        assert ri_per_char == [None] * 64
+        assert ri_overall is None
+
+    def test_large_constant_matrix_has_no_retention_index(self):
+        columns = [["0"] * 64 for _ in range(64)]
+
+        ri_per_char, ri_overall = retention_index(columns, [0] * 64)
+
+        assert ri_per_char == [None] * 64
+        assert ri_overall is None
+
+    @pytest.mark.parametrize("states", [("α", "β"), ("AA", "BB")])
+    def test_large_non_single_ascii_states_use_counter_fallback(self, states):
+        first, second = states
+        informative = [first, first, second, second] * 16
+        columns = [informative for _ in range(64)]
+
+        ri_per_char, ri_overall = retention_index(columns, [1] * 64)
+
+        assert ri_per_char == [1.0] * 64
+        assert ri_overall == 1.0
+
+    def test_unequal_large_columns_use_counter_fallback(self):
+        columns = [
+            ["0", "0", "1", "1"] * 16,
+            ["0", "1", "0", "1"] * 15,
+        ]
+
+        ri_per_char, ri_overall = retention_index(columns, [1, 2])
+
+        assert ri_per_char == [1.0, pytest.approx(28 / 29)]
+        assert ri_overall == pytest.approx(59 / 60)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/helpers/test_plot_config.py
+++ b/tests/unit/helpers/test_plot_config.py
@@ -9,10 +9,13 @@ from phykit.helpers.plot_config import (
     PlotConfig,
     _assign_internal_y_from_children,
     _mean_child_y,
+    _preorder_clades,
     _preorder_clades_direct,
+    _terminal_clades,
     _terminal_clades_direct,
     add_plot_arguments,
     build_parent_map,
+    cleanup_tree_axes,
     compute_node_positions,
     draw_tree_branches,
     draw_tip_labels,
@@ -210,6 +213,31 @@ class TestResolve:
         config.resolve(n_rows=500, n_cols=500)
         assert config.fig_height == first_height  # not overwritten
 
+    def test_resolve_uses_square_dimensions_for_circular_tree(self):
+        config = PlotConfig(circular=True)
+
+        config.resolve(n_rows=200)
+
+        assert config.fig_width == 14.0
+        assert config.fig_height == 14.0
+
+    @pytest.mark.parametrize(
+        ("dimensions", "expected_width", "expected_height"),
+        [
+            ({"fig_width": 11.0}, 11.0, 5.0),
+            ({"fig_height": 9.0}, 14.0, 9.0),
+        ],
+    )
+    def test_resolve_preserves_partial_circular_dimensions(
+        self, dimensions, expected_width, expected_height
+    ):
+        config = PlotConfig(circular=True, **dimensions)
+
+        config.resolve(n_rows=10)
+
+        assert config.fig_width == expected_width
+        assert config.fig_height == expected_height
+
 
 class TestAddPlotArguments:
     def _make_parser(self):
@@ -354,6 +382,15 @@ class TestComputeNodePositions:
         assert iterable.iterations == 1
         assert _mean_child_y([object()], {}) == 0.0
 
+    def test_assign_internal_y_averages_available_binary_child(self):
+        left = object()
+        right = object()
+        parent = type("Clade", (), {"clades": [left, right]})()
+
+        assert _assign_internal_y_from_children(
+            parent, {id(left): 3.0}
+        ) == pytest.approx(3.0)
+
     def test_build_parent_map_uses_direct_tree_traversal(self, monkeypatch):
         tree = self._make_tree()
 
@@ -481,6 +518,24 @@ class TestComputeNodePositions:
         assert node_y[id(tree.root)] == pytest.approx(1.25)
 
     @pytest.mark.parametrize("cladogram", [False, True])
+    def test_tree_layout_supports_non_list_child_sequences(self, cladogram):
+        tree = self._make_tree()
+        expected_parent_map = build_parent_map(tree)
+        expected_x, expected_y = compute_node_positions(
+            tree, expected_parent_map, cladogram=cladogram
+        )
+        tree.root.clades = tuple(tree.root.clades)
+
+        parent_map = build_parent_map(tree)
+        node_x, node_y = compute_node_positions(
+            tree, parent_map, cladogram=cladogram
+        )
+
+        assert parent_map == expected_parent_map
+        assert node_x == pytest.approx(expected_x)
+        assert node_y == pytest.approx(expected_y)
+
+    @pytest.mark.parametrize("cladogram", [False, True])
     def test_compute_node_positions_reuses_precomputed_preorder(self, cladogram):
         tree = self._make_tree()
         parent_map = build_parent_map(tree)
@@ -501,6 +556,30 @@ class TestComputeNodePositions:
         assert observed_x == pytest.approx(expected_x)
         assert observed_y == pytest.approx(expected_y)
 
+    @pytest.mark.parametrize("cladogram", [False, True])
+    def test_precomputed_layout_ignores_clades_without_parents(self, cladogram):
+        tree = self._make_tree()
+        parent_map = build_parent_map(tree)
+        orphan = type(
+            "Clade",
+            (),
+            {"clades": [], "branch_length": 2.0},
+        )()
+        preorder_clades = list(tree.find_clades(order="preorder")) + [orphan]
+
+        node_x, node_y = compute_node_positions(
+            tree,
+            parent_map,
+            cladogram=cladogram,
+            preorder_clades=preorder_clades,
+        )
+
+        assert id(orphan) in node_y
+        if cladogram:
+            assert node_x[id(orphan)] == pytest.approx(1.0)
+        else:
+            assert id(orphan) not in node_x
+
     def test_direct_clade_helpers_preserve_mixed_child_order(self, monkeypatch):
         tree = Phylo.read(
             StringIO("(A:1,(B:1,C:1):1,(D:1,E:1,F:1):1,G:1);"),
@@ -518,6 +597,121 @@ class TestComputeNodePositions:
         assert _preorder_clades_direct(tree) == expected_preorder
         assert _terminal_clades_direct(tree) == expected_terminals
 
+    def test_clade_helpers_fall_back_for_legacy_tree_interface(self):
+        tip = object()
+
+        class LegacyTree:
+            def get_terminals(self):
+                return [tip]
+
+            def find_clades(self, order):
+                assert order == "preorder"
+                return iter([tip])
+
+        tree = LegacyTree()
+
+        assert _terminal_clades(tree) == [tip]
+        assert _preorder_clades(tree) == [tip]
+
+    def test_clade_helpers_fall_back_for_incomplete_child_interface(self):
+        tip = object()
+        root = type("Root", (), {"clades": [tip]})()
+
+        class Tree:
+            def __init__(self):
+                self.root = root
+
+            def get_terminals(self):
+                return [tip]
+
+            def find_clades(self, order):
+                assert order == "preorder"
+                return iter([root, tip])
+
+        tree = Tree()
+
+        assert _terminal_clades(tree) == [tip]
+        assert _preorder_clades(tree) == [root, tip]
+
+    def test_draw_tree_branches_skips_incomplete_coordinates(self):
+        tree = self._make_tree()
+        parent_map = build_parent_map(tree)
+        node_x, node_y = compute_node_positions(tree, parent_map)
+        missing_parent = tree.root.clades[1]
+        missing_x = tree.root.clades[0].clades[0]
+        parent_map.pop(id(missing_parent))
+        node_x.pop(id(missing_x))
+        colored_clades = []
+
+        class Axes:
+            def __init__(self):
+                self.calls = []
+
+            def plot(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+
+        def branch_color(clade):
+            colored_clades.append(clade)
+            return "red"
+
+        ax = Axes()
+        draw_tree_branches(
+            ax, tree, node_x, node_y, parent_map, color=branch_color
+        )
+
+        assert len(ax.calls) == 4
+        assert len(colored_clades) == 2
+        assert [call[1]["color"] for call in ax.calls[::2]] == ["red", "red"]
+
+    def test_batched_tree_branches_skip_incomplete_coordinates(self):
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        tree = self._make_tree()
+        parent_map = build_parent_map(tree)
+        node_x, node_y = compute_node_positions(tree, parent_map)
+        parent_map.pop(id(tree.root.clades[1]))
+        node_x.pop(id(tree.root.clades[0].clades[0]))
+        colored_clades = []
+        fig, ax = plt.subplots()
+
+        try:
+            draw_tree_branches(
+                ax,
+                tree,
+                node_x,
+                node_y,
+                parent_map,
+                color=lambda clade: colored_clades.append(clade) or "red",
+            )
+
+            assert len(ax.collections) == 2
+            assert all(len(collection.get_segments()) == 2 for collection in ax.collections)
+            assert len(colored_clades) == 2
+        finally:
+            plt.close(fig)
+
+    def test_batched_tree_branches_allow_empty_parent_map(self):
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        tree = self._make_tree()
+        node_x, node_y = compute_node_positions(tree, build_parent_map(tree))
+        fig, ax = plt.subplots()
+
+        try:
+            draw_tree_branches(ax, tree, node_x, node_y, {})
+
+            assert len(ax.collections) == 0
+        finally:
+            plt.close(fig)
+
     def test_draw_tip_labels_uses_direct_terminal_traversal(self, monkeypatch):
         tree = self._make_tree()
         parent_map = build_parent_map(tree)
@@ -533,6 +727,36 @@ class TestComputeNodePositions:
                 return None
 
         draw_tip_labels(Ax(), tree, node_x, node_y)
+
+    def test_draw_tip_labels_suppresses_nonpositive_font_size(self):
+        class Axes:
+            def text(self, *args, **kwargs):
+                raise AssertionError("suppressed labels should not be drawn")
+
+        draw_tip_labels(Axes(), self._make_tree(), {}, {}, fontsize=0)
+
+    @pytest.mark.parametrize("show_xlabel", [False, True])
+    def test_cleanup_tree_axes(self, show_xlabel):
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        ax.set_xlabel("Existing label")
+
+        try:
+            cleanup_tree_axes(ax, show_xlabel=show_xlabel)
+
+            assert len(ax.get_yticks()) == 0
+            assert not ax.spines["top"].get_visible()
+            assert not ax.spines["right"].get_visible()
+            assert not ax.spines["left"].get_visible()
+            expected = "Branch length" if show_xlabel else "Existing label"
+            assert ax.get_xlabel() == expected
+        finally:
+            plt.close(fig)
 
 
 class TestApplyToFigure:
@@ -585,6 +809,44 @@ class TestApplyToFigure:
         config.apply_to_figure(fig, ax, default_title="T", default_colors=["red"])
         legend = ax.get_legend()
         assert legend is None or not legend.get_visible()
+        plt.close(fig)
+
+    def test_repositions_existing_legend_and_applies_font_sizes(self):
+        import matplotlib.pyplot as plt
+
+        fig, ax = self._make_fig_ax()
+        ax.lines[0].set_label("observed")
+        ax.legend(loc="upper right")
+        ax.set_xlabel("X")
+        ax.set_ylabel("Y")
+        ax.set_xticks([0, 1])
+        ax.set_yticks([0, 1])
+        config = PlotConfig(
+            legend_position="lower left",
+            axis_fontsize=11.0,
+            ylabel_fontsize=6.0,
+            xlabel_fontsize=5.0,
+        )
+
+        config.apply_to_figure(fig, ax, default_title="T", default_colors=["red"])
+
+        assert ax.get_legend()._loc == 3
+        assert ax.xaxis.label.get_fontsize() == 11.0
+        assert ax.yaxis.label.get_fontsize() == 11.0
+        assert all(label.get_fontsize() == 6.0 for label in ax.get_yticklabels())
+        assert all(label.get_fontsize() == 5.0 for label in ax.get_xticklabels())
+        plt.close(fig)
+
+    @pytest.mark.parametrize("legend_position", ["none", "upper right"])
+    def test_legend_options_allow_axes_without_legend(self, legend_position):
+        import matplotlib.pyplot as plt
+
+        fig, ax = self._make_fig_ax()
+        config = PlotConfig(legend_position=legend_position)
+
+        config.apply_to_figure(fig, ax, default_title="T", default_colors=["red"])
+
+        assert ax.get_legend() is None
         plt.close(fig)
 
     def test_returns_merged_colors(self):

--- a/tests/unit/helpers/test_tree_paths.py
+++ b/tests/unit/helpers/test_tree_paths.py
@@ -78,6 +78,23 @@ def test_build_object_parent_map_handles_mixed_child_counts(monkeypatch):
     assert parent_map[trifurcation.clades[2]] is trifurcation
 
 
+def test_build_object_parent_map_falls_back_for_legacy_tree():
+    root = Clade(name="root", clades=[Clade(name="A"), Clade(name="B")])
+
+    class LegacyTree:
+        root = object()
+
+        @staticmethod
+        def find_clades(order):
+            assert order == "preorder"
+            return [root, *root.clades]
+
+    parent_map = build_object_parent_map(LegacyTree())
+
+    assert parent_map[root.clades[0]] is root
+    assert parent_map[root.clades[1]] is root
+
+
 def test_build_root_path_map_uses_direct_traversal(monkeypatch):
     tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
 
@@ -115,6 +132,69 @@ def test_build_root_path_map_binary_children_do_not_call_reversed():
     right = tree.root.clades[1]
     assert paths[left.clades[0]] == [tree.root, left, left.clades[0]]
     assert paths[right.clades[1]] == [tree.root, right, right.clades[1]]
+
+
+def test_build_root_path_map_handles_multifurcations():
+    tree = NewickTree(
+        root=Clade(
+            name="root",
+            clades=[Clade(name="A"), Clade(name="B"), Clade(name="C")],
+        )
+    )
+
+    paths = build_root_path_map(tree)
+
+    for child in tree.root.clades:
+        assert paths[child] == [tree.root, child]
+
+
+def test_build_root_path_map_uses_legacy_traversal_for_alternate_root():
+    root = Clade(name="root", clades=[Clade(name="A"), Clade(name="B")])
+
+    class LegacyTree:
+        root = object()
+
+        @staticmethod
+        def find_clades(order):
+            assert order == "preorder"
+            return [root, *root.clades]
+
+    paths = build_root_path_map(LegacyTree(), root=root)
+
+    assert paths[root] == [root]
+    assert paths[root.clades[0]] == [root, root.clades[0]]
+    assert paths[root.clades[1]] == [root, root.clades[1]]
+
+
+def test_build_root_path_map_rejects_disconnected_legacy_traversal():
+    requested_root = Clade(name="requested")
+    disconnected = Clade(name="disconnected")
+
+    class LegacyTree:
+        root = object()
+
+        @staticmethod
+        def find_clades(order):
+            assert order == "preorder"
+            return [disconnected]
+
+    assert build_root_path_map(LegacyTree(), root=requested_root) == {}
+
+
+def test_build_root_path_map_falls_back_when_root_has_no_children_attribute():
+    class LegacyRoot:
+        pass
+
+    class LegacyTree:
+        root = LegacyRoot()
+
+        @staticmethod
+        def find_clades(order):
+            assert order == "preorder"
+            return []
+
+    root = LegacyTree.root
+    assert build_root_path_map(LegacyTree()) == {root: [root]}
 
 
 def test_path_from_root_returns_none_for_incomplete_parent_map():

--- a/tests/unit/services/alignment/test_column_score_service.py
+++ b/tests/unit/services/alignment/test_column_score_service.py
@@ -73,6 +73,12 @@ def test_lazy_alignio_caches_resolved_read():
         real_alignio.read = original_read
 
 
+def test_column_score_helpers_clean_wrapped_sequences_and_unknown_sizes():
+    assert module._clean_fasta_sequence(["ac ", "g\r"]) == "ACG"
+    assert module._alignment_size(iter(())) is None
+    assert module._alignment_length(object()) is None
+
+
 @pytest.fixture
 def args():
     return Namespace(fasta="/some/path/to/query.fa", reference="/some/path/to/ref.fa")
@@ -485,3 +491,162 @@ class TestColumnScore:
         mocked_json = mocker.patch("phykit.services.alignment.column_score.print_json")
         service.run()
         mocked_json.assert_called_once_with({"column_score": 0.5})
+
+    def test_run_unicode_alignment_uses_column_string_fallback(
+        self, args, mocker
+    ):
+        service = ColumnScore(args)
+        query = [SimpleNamespace(seq="AΩ"), SimpleNamespace(seq="TΩ")]
+        reference = [SimpleNamespace(seq="AΩ"), SimpleNamespace(seq="GΩ")]
+        mocker.patch(
+            "phykit.services.alignment.column_score.get_alignment_and_format",
+            side_effect=[
+                (query, "fasta", False),
+                (reference, "fasta", False),
+            ],
+        )
+        mocked_print = mocker.patch("builtins.print")
+
+        service.run()
+
+        mocked_print.assert_called_once_with(0.5)
+
+    def test_run_direct_fasta_json_output(self, tmp_path, mocker):
+        query = tmp_path / "query.fa"
+        reference = tmp_path / "reference.fa"
+        query.write_text(">a\nACGT\n>b\nTGCA\n")
+        reference.write_text(">a\nACGA\n>b\nTGCT\n")
+        service = ColumnScore(
+            Namespace(
+                fasta=str(query),
+                reference=str(reference),
+                json=True,
+            )
+        )
+        mocked_json = mocker.patch(
+            "phykit.services.alignment.column_score.print_json"
+        )
+
+        service.run()
+
+        mocked_json.assert_called_once_with({"column_score": 0.75})
+
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            "",
+            "ACGT\n>a\nACGT\n",
+            ">a\nACGT\n>b\nACG\n>c\nACGT\n",
+            ">a\nACGT\n>b\nACG\n",
+        ],
+    )
+    def test_fasta_reader_rejects_empty_malformed_and_ragged_input(
+        self, tmp_path, contents
+    ):
+        path = tmp_path / "input.fa"
+        path.write_text(contents)
+
+        assert ColumnScore._read_fasta_sequences_upper(str(path)) is None
+
+    def test_fasta_reader_cleans_wrapped_sequences(self, tmp_path):
+        path = tmp_path / "wrapped.fa"
+        path.write_bytes(b">a\nac \ng\r\n>b\nAC\nG\n")
+
+        assert ColumnScore._read_fasta_sequences_upper(str(path)) == [
+            "ACG",
+            "ACG",
+        ]
+
+    def test_direct_fasta_path_reuses_query_and_handles_io_failures(self, tmp_path):
+        path = tmp_path / "same.fa"
+        path.write_text(">a\nACGT\n>b\nTGCA\n")
+
+        assert ColumnScore._calculate_fasta_paths_direct(
+            str(path), str(path)
+        ) == (4, 4)
+        assert ColumnScore._calculate_fasta_paths_direct(
+            str(tmp_path / "missing.fa"), str(path)
+        ) is None
+        assert ColumnScore._calculate_fasta_paths_direct(
+            str(path), str(tmp_path / "missing.fa")
+        ) is None
+
+    def test_direct_fasta_path_rejects_malformed_reference(self, tmp_path):
+        query = tmp_path / "query.fa"
+        reference = tmp_path / "reference.fa"
+        query.write_text(">a\nACGT\n")
+        reference.write_text("not fasta\n")
+
+        assert ColumnScore._calculate_fasta_paths_direct(
+            str(reference), str(query)
+        ) is None
+
+    def test_sequence_list_helpers_cover_large_and_unicode_inputs(self):
+        sequences = [
+            "".join("A" if (idx >> bit) & 1 else "C" for bit in range(4))
+            for idx in range(9)
+        ]
+        query_sequences = [sequence[:-1] + "G" for sequence in sequences]
+        expected = (
+            len(set(zip(*sequences)).intersection(set(zip(*query_sequences)))),
+            4,
+        )
+
+        assert ColumnScore._small_ascii_column_set(sequences) is None
+        assert ColumnScore._unique_column_count_ascii(sequences, 4) == len(
+            set(zip(*sequences))
+        )
+        assert ColumnScore._calculate_matches_between_sequence_lists(
+            sequences,
+            query_sequences,
+        ) == expected
+        assert ColumnScore._calculate_matches_between_sequence_lists([], []) is None
+        assert ColumnScore._calculate_matches_between_sequence_lists(
+            ["AA"],
+            ["AA", "AA"],
+        ) == (0, 2)
+        assert ColumnScore._unique_column_count_ascii(["AΩ"] * 9, 2) is None
+        assert ColumnScore._calculate_matches_between_sequence_lists(
+            ["AΩ"] * 9,
+            ["TΩ"] * 9,
+        ) is None
+
+    def test_repeated_sequence_symbol_helper_rejects_mixed_and_unicode_rows(self):
+        assert ColumnScore._repeated_sequence_symbols_ascii(
+            ["AAAA", "AAAT"]
+        ) is None
+        assert ColumnScore._repeated_sequence_symbols_ascii(
+            ["AΩ", "AΩ"]
+        ) is None
+
+    def test_alignment_direct_helper_rejects_empty_and_ragged_inputs(self, args):
+        service = ColumnScore(args)
+        empty = MultipleSeqAlignment([])
+        ragged = [
+            SimpleNamespace(seq="ACGT"),
+            SimpleNamespace(seq="ACG"),
+        ]
+
+        assert service._calculate_matches_between_alignments_direct(
+            empty, empty
+        ) is None
+        assert service._calculate_matches_between_alignments_direct(
+            ragged, ragged
+        ) is None
+        assert service._calculate_matches_between_alignments_direct(
+            ragged,
+            [SimpleNamespace(seq="ACGT"), SimpleNamespace(seq="TGCA")],
+        ) is None
+        assert service._calculate_matches_between_alignments_direct(
+            [], [SimpleNamespace(seq="ACGT")]
+        ) is None
+
+    def test_alignment_direct_helper_handles_unknown_size_taxon_mismatch(
+        self, args
+    ):
+        service = ColumnScore(args)
+
+        assert service._calculate_matches_between_alignments_direct(
+            iter([SimpleNamespace(seq="ACGT"), SimpleNamespace(seq="TGCA")]),
+            iter([SimpleNamespace(seq="ACGT")]),
+        ) == (0, 4)

--- a/tests/unit/services/alignment/test_composition_per_taxon.py
+++ b/tests/unit/services/alignment/test_composition_per_taxon.py
@@ -811,3 +811,335 @@ assert "Bio.SeqIO.FastaIO" not in sys.modules
         svc.run()
         out, _ = capsys.readouterr()
         assert out == ""
+
+    def test_scalar_helpers_cover_empty_invalid_and_zero_rows(self):
+        assert composition_per_taxon_module._composition_per_taxon_scalar(
+            [],
+            {"-", "?", "N"},
+        ) == ([], [])
+        assert composition_per_taxon_module._composition_per_taxon_scalar(
+            [("t1", "---"), ("t2", "???")],
+            {"-", "?", "N"},
+        ) == ([], [])
+
+        symbols, rows = composition_per_taxon_module._composition_per_taxon_scalar(
+            [("invalid", "---"), ("valid", "AAA")],
+            {"-", "?", "N"},
+        )
+        assert symbols == ["A"]
+        assert rows[0][0] == "invalid"
+        assert rows[0][1] == [0.0]
+        assert rows[1][1] == [1.0]
+
+    def test_parser_helpers_clean_wrapped_and_unicode_sequences(self):
+        assert composition_per_taxon_module._clean_simple_fasta_sequence(
+            ["ac ", "g\r"]
+        ) == "acg"
+        assert composition_per_taxon_module._sequence_has_protein_symbols(
+            "ACGTN-?*"
+        ) is False
+        assert composition_per_taxon_module._sequence_has_protein_symbols(
+            "ACΩT"
+        ) is True
+
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            "",
+            "not fasta\n>t1\nACGT\n",
+            ">t1\nACGT\n>t2\nACG\n",
+            ">t1\nACGT\n>t2\nACG\n>t3\nACGT\n",
+        ],
+    )
+    def test_simple_fasta_reader_rejects_invalid_inputs(
+        self, tmp_path, contents
+    ):
+        path = tmp_path / "input.fa"
+        path.write_text(contents)
+
+        assert composition_per_taxon_module._read_small_simple_fasta_records(
+            str(path)
+        ) is None
+
+    def test_simple_fasta_reader_handles_missing_and_oversized_inputs(
+        self, tmp_path, monkeypatch
+    ):
+        assert composition_per_taxon_module._read_small_simple_fasta_records(
+            str(tmp_path / "missing.fa")
+        ) is None
+
+        path = tmp_path / "large.fa"
+        path.write_text(">t1\nACGT\n>t2\nACGT\n")
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_COMPOSITION_SCALAR_MAX_CELLS",
+            4,
+        )
+        assert composition_per_taxon_module._read_small_simple_fasta_records(
+            str(path)
+        ) is None
+
+    def test_bounded_count_dtype_supports_all_integer_ranges(self):
+        assert composition_per_taxon_module._bounded_ascii_count_dtype(
+            0xFFFF
+        ) is np.uint16
+        assert composition_per_taxon_module._bounded_ascii_count_dtype(
+            0x10000
+        ) is np.uint32
+        assert composition_per_taxon_module._bounded_ascii_count_dtype(
+            0x100000000
+        ) is np.uint64
+
+    def test_invalid_lookup_cache_reuses_existing_array(self, args):
+        service = CompositionPerTaxon(args)
+        service._INVALID_LOOKUP_CACHE.clear()
+
+        first = service._invalid_lookup_for_chars({"n", "?"})
+        second = service._invalid_lookup_for_chars({"N", "?"})
+
+        assert second is first
+
+    def test_calculate_composition_accepts_unknown_length_iterables(self, args):
+        service = CompositionPerTaxon(args)
+        records = iter(
+            [
+                SimpleNamespace(id="a", seq="ACGT"),
+                SimpleNamespace(id="b", seq="AGGT"),
+            ]
+        )
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            records,
+            is_protein=False,
+        )
+
+        assert symbols == ["A", "C", "G", "T"]
+        assert [record_id for record_id, _ in rows] == ["a", "b"]
+        assert service.calculate_composition_per_taxon([], False) == ([], [])
+
+    def test_indexed_single_record_skips_zero_sample(self, args, monkeypatch):
+        class IndexedAlignment:
+            records = [SimpleNamespace(id="only", seq="ACGT")]
+
+            def __len__(self):
+                return 1
+
+            def __getitem__(self, index):
+                return self.records[index]
+
+            def __iter__(self):
+                raise AssertionError("indexed path should not iterate")
+
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_IDENTICAL_INDEXED_SCAN_MIN_RECORDS",
+            1,
+        )
+        service = CompositionPerTaxon(args)
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            IndexedAlignment(),
+            is_protein=False,
+        )
+
+        assert symbols == ["A", "C", "G", "T"]
+        assert [record_id for record_id, _ in rows] == ["only"]
+
+    def test_indexed_identical_unicode_and_invalid_sequences(
+        self, args, monkeypatch
+    ):
+        class IndexedAlignment:
+            def __init__(self, sequence):
+                self.records = [
+                    SimpleNamespace(id=f"t{idx}", seq=sequence)
+                    for idx in range(3)
+                ]
+
+            def __len__(self):
+                return len(self.records)
+
+            def __getitem__(self, index):
+                return self.records[index]
+
+            def __iter__(self):
+                raise AssertionError("indexed path should not iterate")
+
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_IDENTICAL_INDEXED_SCAN_MIN_RECORDS",
+            3,
+        )
+        service = CompositionPerTaxon(args)
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            IndexedAlignment("AΩA"),
+            is_protein=True,
+        )
+        assert symbols == ["A", "Ω"]
+        np.testing.assert_allclose(rows[0][1], [2 / 3, 1 / 3])
+        assert service.calculate_composition_per_taxon(
+            IndexedAlignment("---"),
+            is_protein=False,
+        ) == ([], [])
+
+    @pytest.mark.parametrize("mismatch_index", [1, 2])
+    def test_indexed_scan_mismatches_fall_back_to_complete_alignment(
+        self, args, monkeypatch, mismatch_index
+    ):
+        class IndexedAlignment:
+            def __init__(self):
+                self.records = [
+                    SimpleNamespace(
+                        id=f"t{idx}",
+                        seq="TCGT" if idx == mismatch_index else "ACGT",
+                    )
+                    for idx in range(5)
+                ]
+
+            def __len__(self):
+                return len(self.records)
+
+            def __getitem__(self, index):
+                return self.records[index]
+
+            def __iter__(self):
+                return iter(self.records)
+
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_IDENTICAL_INDEXED_SCAN_MIN_RECORDS",
+            5,
+        )
+        service = CompositionPerTaxon(args)
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            IndexedAlignment(),
+            is_protein=False,
+        )
+
+        assert symbols == ["A", "C", "G", "T"]
+        assert len(rows) == 5
+
+    def test_indexed_scan_errors_fall_back_to_iteration(self, args, monkeypatch):
+        class FragileIndexedAlignment:
+            records = [
+                SimpleNamespace(id="t0", seq="ACGT"),
+                SimpleNamespace(id="t1", seq="AGGT"),
+                SimpleNamespace(id="t2", seq="ATGT"),
+            ]
+
+            def __len__(self):
+                return len(self.records)
+
+            def __getitem__(self, index):
+                if index:
+                    raise TypeError("indexing unavailable")
+                return self.records[index]
+
+            def __iter__(self):
+                return iter(self.records)
+
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_IDENTICAL_INDEXED_SCAN_MIN_RECORDS",
+            3,
+        )
+        service = CompositionPerTaxon(args)
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            FragileIndexedAlignment(),
+            is_protein=False,
+        )
+
+        assert symbols == ["A", "C", "G", "T"]
+        assert len(rows) == 3
+
+    def test_forced_matrix_backends_match_scalar_compositions(
+        self, args, monkeypatch
+    ):
+        def composition_oracle(records, invalid_chars):
+            invalid = {char.upper() for char in invalid_chars}
+            valid_rows = [
+                [char for char in str(record.seq).upper() if char not in invalid]
+                for record in records
+            ]
+            symbols = sorted({char for row in valid_rows for char in row})
+            values = [
+                [row.count(symbol) / len(row) if row else 0.0 for symbol in symbols]
+                for row in valid_rows
+            ]
+            return symbols, values
+
+        service = CompositionPerTaxon(args)
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_COMPOSITION_SCALAR_MAX_CELLS",
+            0,
+        )
+        monkeypatch.setattr(
+            composition_per_taxon_module,
+            "_ASCII_OFFSET_BINCOUNT_MAX_ROWS",
+            1,
+        )
+
+        cases = [
+            (
+                [
+                    SimpleNamespace(id="a", seq="A-A"),
+                    SimpleNamespace(id="b", seq="AAA"),
+                ],
+                False,
+            ),
+            (
+                [
+                    SimpleNamespace(id="a", seq="ACDEFGHIKLMNPQRSTVWY"),
+                    SimpleNamespace(id="b", seq="YWVTSRQPNMLKIHGFEDCA"),
+                ],
+                True,
+            ),
+            (
+                [
+                    SimpleNamespace(id="a", seq="AΩCC"),
+                    SimpleNamespace(id="b", seq="TΩGG"),
+                ],
+                True,
+            ),
+        ]
+
+        for records, is_protein in cases:
+            symbols, rows = service.calculate_composition_per_taxon(
+                records,
+                is_protein=is_protein,
+            )
+            expected_symbols, expected_rows = composition_oracle(
+                records,
+                service.get_gap_chars(is_protein),
+            )
+            assert symbols == expected_symbols
+            np.testing.assert_allclose(
+                [values for _, values in rows],
+                expected_rows,
+            )
+
+    def test_identical_unicode_and_invalid_matrix_shortcuts(self, args):
+        service = CompositionPerTaxon(args)
+        unicode_records = [
+            SimpleNamespace(id="a", seq="AΩA"),
+            SimpleNamespace(id="b", seq="aωa"),
+        ]
+        invalid_records = [
+            SimpleNamespace(id="a", seq="---"),
+            SimpleNamespace(id="b", seq="---"),
+        ]
+
+        symbols, rows = service.calculate_composition_per_taxon(
+            unicode_records,
+            is_protein=True,
+        )
+
+        assert symbols == ["A", "Ω"]
+        np.testing.assert_allclose(rows[0][1], [2 / 3, 1 / 3])
+        assert service.calculate_composition_per_taxon(
+            invalid_records,
+            is_protein=False,
+        ) == ([], [])

--- a/tests/unit/services/alignment/test_dna_threader_service.py
+++ b/tests/unit/services/alignment/test_dna_threader_service.py
@@ -135,6 +135,11 @@ assert "Bio.AlignIO" not in sys.modules
         service = DNAThreader(args)
         assert service.create_mask(6) == [True] * 6
 
+    def test_clipkit_log_data_is_none_without_log(self, args):
+        service = DNAThreader(args)
+
+        assert service.clipkit_log_data is None
+
     def test_create_mask_reads_clipkit_log_once(self, args, mocker):
         args.clipkit_log_file = "clipkit.log"
         service = DNAThreader(args)
@@ -242,6 +247,17 @@ assert "Bio.AlignIO" not in sys.modules
 
         assert threaded == "AAACCCGGG"
 
+    def test_thread_sequence_terminal_stop_with_gap_restores_stop_codon(self, args):
+        service = DNAThreader(args)
+
+        threaded = service._thread_sequence(
+            "A-*",
+            "AAATAG",
+            [True] * 9,
+        )
+
+        assert threaded == "AAA---TAG"
+
     def test_thread_sequence_accepts_plain_strings(self, args):
         service = DNAThreader(args)
 
@@ -295,6 +311,39 @@ assert "Bio.AlignIO" not in sys.modules
         )
 
         assert observed == thread_codons_oracle(protein, nucleotide, keep_mask)
+
+    @pytest.mark.parametrize(
+        ("protein", "oracle_protein"),
+        [
+            ("A-C", "A-C"),
+            ("A-*", "A-!"),
+        ],
+    )
+    def test_thread_sequence_legacy_grouped_plan_matches_codon_oracle(
+        self, args, protein, oracle_protein
+    ):
+        service = DNAThreader(args)
+        nucleotide = "AAACCC"
+        keep_mask = [
+            True, False, False,
+            True, True, True,
+            True, True, True,
+        ]
+        grouped_keep_bits = [(1,), (7,), (7,)]
+        legacy_plan = (9, False, [1, 7, 7], grouped_keep_bits)
+
+        observed = service._thread_sequence(
+            protein,
+            nucleotide,
+            keep_mask,
+            keep_mask_plan=legacy_plan,
+        )
+
+        assert observed == thread_codons_oracle(
+            oracle_protein,
+            nucleotide,
+            keep_mask,
+        )
 
     def test_has_gap_char_detects_threading_gap_symbols(self):
         assert DNAThreader._has_gap_char("ACD") is False
@@ -459,6 +508,111 @@ assert "Bio.AlignIO" not in sys.modules
 
         assert observed == "CCC"
 
+    @pytest.mark.parametrize(
+        ("protein", "nucleotide", "keep_mask"),
+        [
+            (
+                "A-CD",
+                "AAACCCGGG",
+                [False] * 3
+                + [True, False, False]
+                + [False, True, False]
+                + [False, False, True],
+            ),
+            ("A-C", "AAACCC", [False] * 9),
+            ("A-C", "AAACCC", [False] * 6 + [True, False, False]),
+            ("A-C", "AAACCC", [True] * 6 + [True, False, False]),
+            (
+                "ABC",
+                "AAAC",
+                [True, False, True] * 2 + [True, False, False],
+            ),
+        ],
+    )
+    def test_emit_plans_match_codon_oracle_for_mask_shapes(
+        self, args, protein, nucleotide, keep_mask
+    ):
+        service = DNAThreader(args)
+        plan = service._create_thread_mask_plan(keep_mask, len(protein))
+
+        observed = service._thread_sequence(
+            protein,
+            nucleotide,
+            keep_mask,
+            keep_mask_plan=plan,
+        )
+
+        assert observed == thread_codons_oracle(protein, nucleotide, keep_mask)
+
+    @pytest.mark.parametrize(
+        "keep_mask",
+        [
+            [True, False, True] * 3,
+            [True, False, True] * 2 + [True, False, False],
+        ],
+    )
+    def test_terminal_stop_emit_plans_match_restored_stop_oracle(
+        self, args, keep_mask
+    ):
+        service = DNAThreader(args)
+        protein = "AC*"
+        nucleotide = "AAACCCTAG"
+        plan = service._create_thread_mask_plan(keep_mask, len(protein))
+
+        observed = service._thread_sequence(
+            protein,
+            nucleotide,
+            keep_mask,
+            keep_mask_plan=plan,
+        )
+
+        assert observed == thread_codons_oracle("AC!", nucleotide, keep_mask)
+
+    @pytest.mark.parametrize(
+        ("keep_mask", "expected"),
+        [
+            ([True, False, True] * 2 + [False] * 3, "AA--"),
+            ([True, False, True] * 2 + [True] * 3, "AA--CCC"),
+            ([True, False, True] * 2 + [True, False, False], "AACC-"),
+        ],
+    )
+    def test_uniform_prefix_tail_emitters_preserve_gap_and_trim_semantics(
+        self, args, keep_mask, expected
+    ):
+        service = DNAThreader(args)
+        protein = "A-C" if expected != "AACC-" else "AB-"
+        nucleotide = "AAACCC"
+        plan = service._create_thread_mask_plan(keep_mask, len(protein))
+
+        observed = service._thread_sequence(
+            protein,
+            nucleotide,
+            keep_mask,
+            keep_mask_plan=plan,
+        )
+
+        assert observed == expected
+        assert observed == thread_codons_oracle(protein, nucleotide, keep_mask)
+
+    def test_uniform_full_segment_helper_matches_codon_oracle(self, args):
+        service = DNAThreader(args)
+        protein = "A-C"
+        nucleotide = "AAACCC"
+        keep_mask = [True] * 9
+        emitters = service._create_thread_mask_plan(
+            keep_mask,
+            len(protein),
+        )[4]
+
+        observed = service._thread_uniform_emit_plan(
+            protein,
+            nucleotide,
+            emitters,
+            emitters.uniform_selectors,
+        )
+
+        assert observed == thread_codons_oracle(protein, nucleotide, keep_mask)
+
     def test_thread_sequence_emit_plan_matches_terminal_stop_path(self, args):
         class NoIndexMask(list):
             def __getitem__(self, item):
@@ -588,6 +742,17 @@ assert "Bio.AlignIO" not in sys.modules
             "AAACCC"
         )
 
+    def test_thread_all_sites_kept_pads_truncated_codons(self, args):
+        service = DNAThreader(args)
+
+        threaded = service._thread_sequence(
+            "AA-C",
+            "AAAC",
+            [True] * 12,
+        )
+
+        assert threaded == thread_codons_oracle("AA-C", "AAAC", [True] * 12)
+
     def test_thread_sequence_all_keep_hint_skips_mask_scan(self, args):
         class NoScanMask(list):
             def __iter__(self):
@@ -627,6 +792,24 @@ assert "Bio.AlignIO" not in sys.modules
 
         pal2nal = service.thread(iter(prot_records))
         assert pal2nal["gene1"] == "AAACCC"
+
+    def test_thread_exits_when_nucleotide_sequence_is_missing(
+        self, mocker, args, capsys
+    ):
+        service = DNAThreader(args)
+        prot_records = [SeqRecord(Seq("AC"), id="gene1")]
+        mocker.patch(
+            "phykit.services.alignment.dna_threader.SeqIO.parse",
+            return_value=iter([]),
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            service.thread(iter(prot_records))
+
+        assert excinfo.value.code == 2
+        assert capsys.readouterr().out == (
+            "Nucleotide sequence for gene1 not found.\n"
+        )
 
     def test_thread_reuses_precomputed_mask_plan(self, mocker, args):
         args.clipkit_log_file = "clipkit.log"

--- a/tests/unit/services/alignment/test_gc_content_service.py
+++ b/tests/unit/services/alignment/test_gc_content_service.py
@@ -510,3 +510,174 @@ assert "phykit.helpers.files" not in sys.modules
             service.run()
         assert excinfo.value.code == 2
         mocked_print.assert_called_with("GC content can't be calculated for protein sequences")
+
+    def test_lookup_count_dtype_and_long_invalid_scans(self, monkeypatch):
+        gc_content_module._PROTEIN_VALID_LOOKUP = None
+        gc_content_module._GC_LOOKUP = None
+        protein_lookup = gc_content_module._get_valid_lookup(is_protein=True)
+        assert gc_content_module._get_valid_lookup(is_protein=True) is protein_lookup
+        gc_lookup = gc_content_module._get_gc_lookup()
+
+        assert not protein_lookup[ord("X")]
+        assert protein_lookup[ord("N")]
+        assert gc_lookup[ord("G")]
+        assert gc_lookup[ord("c")]
+        assert not gc_lookup[ord("A")]
+        assert gc_content_module._bounded_ascii_count_dtype(
+            0x100000000
+        ) is gc_content_module.np.uint64
+
+        monkeypatch.setattr(gc_content_module, "_INVALID_SCAN_BYTES", 4)
+        assert gc_content_module._has_invalid_bytes(b"-AAAAAAAA", b"-") is True
+        assert gc_content_module._has_invalid_bytes(b"AAAAAAAA-", b"-") is True
+        assert gc_content_module._has_invalid_bytes(b"AAAA-AAAA", b"-") is True
+        assert gc_content_module._has_invalid_bytes(b"AAAAAAAAA", b"-") is False
+
+    def test_ascii_matrix_helper_handles_empty_uneven_and_unicode_records(self):
+        assert gc_content_module._gc_counts_from_ascii_matrix(
+            [], False
+        ) == ([], None, None)
+
+        uneven = [
+            SimpleNamespace(seq="ACGT", id="a"),
+            SimpleNamespace(seq="ACG", id="b"),
+        ]
+        record_data, valid_counts, gc_counts = (
+            gc_content_module._gc_counts_from_ascii_matrix(uneven, False)
+        )
+        assert [record_id for record_id, _ in record_data] == ["a", "b"]
+        assert valid_counts is None
+        assert gc_counts is None
+
+        unicode_records = [
+            SimpleNamespace(id="a", seq="AΩGT"),
+            SimpleNamespace(id="b", seq="TΩGC"),
+        ]
+        _, valid_counts, gc_counts = (
+            gc_content_module._gc_counts_from_ascii_matrix(
+                unicode_records,
+                False,
+            )
+        )
+        assert valid_counts is None
+        assert gc_counts is None
+
+    def test_forced_per_sequence_fallback_matches_scalar_counts(
+        self, args, monkeypatch
+    ):
+        service = GCContent(args)
+        monkeypatch.setattr(
+            gc_content_module,
+            "_GC_PER_SEQUENCE_SCALAR_MAX_BYTES",
+            0,
+        )
+        records = [
+            SimpleNamespace(id="unicode", seq="AΩGC"),
+            SimpleNamespace(id="invalid", seq="----"),
+        ]
+
+        rows = service.calculate_gc_per_sequence_data(records, is_protein=False)
+
+        assert rows == [("unicode", 0.5), ("invalid", 0.0)]
+        monkeypatch.setattr(
+            gc_content_module,
+            "_GC_PER_SEQUENCE_SCALAR_MAX_BYTES",
+            8192,
+        )
+        assert gc_content_module._gc_per_sequence_data_scalar(
+            [SimpleNamespace(id="invalid", seq="----")],
+            False,
+        ) == [("invalid", 0.0)]
+
+    def test_total_ascii_backends_match_expected_counts(self, monkeypatch):
+        assert gc_content_module._gc_total_from_ascii([], False) is None
+        records = _alignment(
+            [SeqRecord(Seq("ACGT"), id="a"), SeqRecord(Seq("TGCA"), id="b")]
+        )
+        monkeypatch.setattr(gc_content_module, "_GC_TOTAL_SCALAR_MAX_BYTES", 0)
+
+        assert gc_content_module._gc_total_from_ascii(records, False) == (8, 4)
+
+        invalid_records = _alignment(
+            [SeqRecord(Seq("AC-T"), id="a"), SeqRecord(Seq("TG?A"), id="b")]
+        )
+        monkeypatch.setattr(
+            gc_content_module,
+            "_GC_TOTAL_BYTE_COUNT_MIN_BYTES",
+            1,
+        )
+        assert gc_content_module._gc_total_from_ascii(
+            invalid_records, False
+        ) == (6, 2)
+
+        monkeypatch.setattr(
+            gc_content_module,
+            "_GC_TOTAL_BYTE_COUNT_MIN_BYTES",
+            1000,
+        )
+        assert gc_content_module._gc_total_from_ascii(
+            invalid_records, False
+        ) == (6, 2)
+
+    def test_run_text_dispatches_verbose_and_summary_paths(self, args, mocker):
+        records = _alignment(
+            [SeqRecord(Seq("ACGT"), id="a"), SeqRecord(Seq("AGGT"), id="b")]
+        )
+        service = GCContent(args)
+        mocker.patch(
+            "phykit.services.alignment.gc_content.get_alignment_and_format",
+            return_value=(records, "fasta", False),
+        )
+        verbose = mocker.patch.object(service, "calculate_gc_per_sequence")
+        summary = mocker.patch.object(service, "calculate_gc_total")
+
+        service.verbose = True
+        service.run()
+        verbose.assert_called_once()
+        summary.assert_not_called()
+
+        service.verbose = False
+        service.run()
+        summary.assert_called_once()
+
+    def test_per_sequence_text_handles_empty_and_broken_pipe(self, args, mocker):
+        service = GCContent(args)
+        mocker.patch.object(
+            service,
+            "calculate_gc_per_sequence_data",
+            return_value=[],
+        )
+        mocked_print = mocker.patch("builtins.print")
+
+        service.calculate_gc_per_sequence([], False)
+        mocked_print.assert_not_called()
+
+        mocker.patch.object(
+            service,
+            "calculate_gc_per_sequence_data",
+            return_value=[("a", 0.5)],
+        )
+        mocked_print.side_effect = BrokenPipeError
+        service.calculate_gc_per_sequence([], False)
+
+    def test_calculate_gc_total_prints_value(self, args, mocker):
+        service = GCContent(args)
+        mocked_print = mocker.patch("builtins.print")
+
+        service.calculate_gc_total(
+            _alignment([SeqRecord(Seq("ACGT"), id="a")]),
+            False,
+        )
+
+        mocked_print.assert_called_once_with(0.5)
+
+    def test_total_value_handles_unicode_only_and_empty_records(self, args):
+        service = GCContent(args)
+
+        assert service.calculate_gc_total_value(
+            [SimpleNamespace(id="unicode", seq="Ω")],
+            False,
+        ) == 0.0
+        with pytest.raises(SystemExit) as exc_info:
+            service.calculate_gc_total_value([], False)
+        assert exc_info.value.code == 2

--- a/tests/unit/services/alignment/test_identity_matrix.py
+++ b/tests/unit/services/alignment/test_identity_matrix.py
@@ -141,6 +141,19 @@ def test_all_sequences_identical_does_not_slice_taxa_names():
     assert identity_matrix_module._all_sequences_identical(sequences, taxa_names) is True
 
 
+def test_identity_matrix_helpers_handle_empty_inputs():
+    assert identity_matrix_module._all_sequences_identical({}, []) is False
+    assert identity_matrix_module._shared_valid_sites(
+        np.empty((0, 3), dtype=bool)
+    ) is None
+
+    matrix = identity_matrix_module._direct_ascii_identity_matrix(
+        np.empty((2, 0), dtype=np.uint8),
+        0,
+    )
+    np.testing.assert_array_equal(matrix, np.eye(2))
+
+
 def test_repeated_cluster_wrappers_cache_scipy_imports(monkeypatch):
     previous_linkage = identity_matrix_module._LINKAGE
     previous_leaves_list = identity_matrix_module._LEAVES_LIST
@@ -1091,3 +1104,170 @@ class TestIdentityMatrixUnit:
         assert len(payload["taxa_order"]) == 3
         # taxon_A and taxon_B are identical, so max should be 1.0
         assert payload["max_identity"]["value"] == 1.0
+
+    def test_parse_alignment_rejects_empty_input(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        service = IdentityMatrix(_make_args("empty.fa", tmp_path / "out.png"))
+        monkeypatch.setattr(
+            service,
+            "get_alignment_and_format",
+            lambda: ([], "fasta", False),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            service._parse_alignment()
+
+        assert exc_info.value.code == 2
+        assert capsys.readouterr().err == (
+            "Error: no sequences found in alignment.\n"
+        )
+
+    def test_run_rejects_single_taxon(self, tmp_path, monkeypatch, capsys):
+        service = IdentityMatrix(_make_args("one.fa", tmp_path / "out.png"))
+        monkeypatch.setattr(
+            service,
+            "_parse_alignment",
+            lambda: ({"only": "ACGT"}, ["only"], 4),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            service.run()
+
+        assert exc_info.value.code == 2
+        assert capsys.readouterr().err == (
+            "Error: alignment must contain at least 2 taxa.\n"
+        )
+
+    def test_run_parses_partition_and_ignores_broken_pipe(
+        self, tmp_path, monkeypatch
+    ):
+        aln_path = tmp_path / "aln.fa"
+        partition_path = tmp_path / "parts.txt"
+        _write_alignment(aln_path, {"a": "ACGT", "b": "ACGA"})
+        partition_path.write_text("DNA, gene=1-4\n")
+        service = IdentityMatrix(
+            _make_args(
+                aln_path,
+                tmp_path / "out.png",
+                sort="alpha",
+                partition=str(partition_path),
+            )
+        )
+        captured = {}
+
+        def capture_plot(*args, **kwargs):
+            captured["partitions"] = kwargs["partitions"]
+
+        monkeypatch.setattr(service, "_plot_heatmap", capture_plot)
+        monkeypatch.setattr(
+            service,
+            "_print_text_output",
+            lambda *args: (_ for _ in ()).throw(BrokenPipeError),
+        )
+
+        service.run()
+
+        assert captured["partitions"] == [("gene", 0, 4)]
+
+    def test_cache_key_failures_and_eviction(self, tmp_path, monkeypatch):
+        missing_service = IdentityMatrix(
+            _make_args(tmp_path / "missing.fa", tmp_path / "out.png")
+        )
+        assert missing_service._run_cache_key() is None
+        assert missing_service._get_cached_run_data() is None
+        missing_service._store_cached_run_data(
+            {}, [], 0, np.empty((0, 0)), [], [], None, (0, 0, [], 0, [])
+        )
+
+        aln_path = tmp_path / "aln.fa"
+        _write_alignment(aln_path, {"a": "AA", "b": "AT"})
+        tree_service = IdentityMatrix(
+            _make_args(
+                aln_path,
+                tmp_path / "tree.png",
+                sort="tree",
+                tree=str(tmp_path / "missing.tree"),
+            )
+        )
+        assert tree_service._run_cache_key()[-1] is None
+
+        service = IdentityMatrix(_make_args(aln_path, tmp_path / "out.png"))
+        identity_matrix_module._IDENTITY_RUN_CACHE.clear()
+        identity_matrix_module._IDENTITY_RUN_CACHE[("old",)] = ("sentinel",)
+        monkeypatch.setattr(identity_matrix_module, "_IDENTITY_RUN_CACHE_MAXSIZE", 1)
+        service._store_cached_run_data(
+            {"a": "AA", "b": "AT"},
+            ["a", "b"],
+            2,
+            np.array([[1.0, 0.5], [0.5, 1.0]]),
+            [0, 1],
+            ["a", "b"],
+            None,
+            (0.5, 0.5, ["a", "b"], 0.5, ["a", "b"]),
+        )
+
+        assert ("old",) not in identity_matrix_module._IDENTITY_RUN_CACHE
+        assert len(identity_matrix_module._IDENTITY_RUN_CACHE) == 1
+        identity_matrix_module._IDENTITY_RUN_CACHE.clear()
+
+    def test_unicode_computation_fallbacks_match_pairwise_oracles(self, tmp_path):
+        service = IdentityMatrix(_make_args("aln.fa", tmp_path / "out.png"))
+        sequences = {"a": "AΩ-T", "b": "AΩGT", "c": "TΩGT"}
+        taxa = ["a", "b", "c"]
+        partitions = [("left", 0, 2), ("right", 2, 4)]
+
+        matrix = service._compute_identity_matrix(sequences, taxa)
+        pairwise_matrix = service._compute_identity_matrix_pairwise(sequences, taxa)
+        names, values = service._compute_partition_identities(
+            sequences,
+            taxa,
+            partitions,
+        )
+        expected_names, expected_values = (
+            service._compute_partition_identities_pairwise(
+                sequences,
+                taxa,
+                partitions,
+            )
+        )
+
+        np.testing.assert_allclose(matrix, pairwise_matrix)
+        assert names == expected_names
+        np.testing.assert_allclose(values, expected_values)
+
+    def test_unicode_pairwise_fallback_sets_all_invalid_pairs_to_zero(
+        self, tmp_path
+    ):
+        service = IdentityMatrix(_make_args("aln.fa", tmp_path / "out.png"))
+        sequences = {"a": "Ω--", "b": "?Ψ?"}
+
+        matrix = service._compute_identity_matrix_pairwise(
+            sequences,
+            ["a", "b"],
+        )
+
+        np.testing.assert_array_equal(matrix, np.eye(2))
+
+    def test_small_ordering_and_partition_strip_edge_cases(self, tmp_path):
+        service = IdentityMatrix(
+            _make_args("aln.fa", tmp_path / "out.png", sort="cluster")
+        )
+        matrix = np.array([[1.0, 0.5], [0.5, 1.0]])
+
+        order, labels = service._determine_order(matrix, ["b", "a"], 2)
+        assert order == [0, 1]
+        assert labels == ["b", "a"]
+
+        service.sort_method = "input"
+        order, labels = service._determine_order(matrix, ["b", "a"], 2)
+        assert order == [0, 1]
+        assert labels == ["b", "a"]
+
+        strip = service._partition_identity_strip(
+            np.empty((0, 2)),
+            [0],
+            n_taxa=1,
+            n_parts=2,
+        )
+        np.testing.assert_array_equal(strip, np.zeros((1, 2)))

--- a/tests/unit/services/alignment/test_identity_matrix.py
+++ b/tests/unit/services/alignment/test_identity_matrix.py
@@ -1271,3 +1271,184 @@ class TestIdentityMatrixUnit:
             n_parts=2,
         )
         np.testing.assert_array_equal(strip, np.zeros((1, 2)))
+
+    def test_partition_identities_large_invalid_alignment_matches_pairwise(
+        self, tmp_path
+    ):
+        service = IdentityMatrix(_make_args("aln.fa", tmp_path / "out.png"))
+        taxa = [f"taxon_{idx}" for idx in range(128)]
+        sequences = {
+            name: ("A-GT" if idx % 2 else "AC?T")
+            for idx, name in enumerate(taxa)
+        }
+        partitions = [("first", 0, 2), ("second", 2, 4)]
+
+        names, observed = service._compute_partition_identities(
+            sequences,
+            taxa,
+            partitions,
+        )
+        expected_names, expected = service._compute_partition_identities_pairwise(
+            sequences,
+            taxa,
+            partitions,
+        )
+
+        assert names == expected_names
+        np.testing.assert_allclose(observed, expected)
+
+    def test_tree_order_falls_back_to_biopython_and_appends_missing_taxa(
+        self, tmp_path, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from Bio import Phylo
+        from phykit.services.tree.base import Tree
+
+        service = IdentityMatrix(
+            _make_args(
+                "aln.fa",
+                tmp_path / "out.png",
+                sort="tree",
+                tree="tree.nwk",
+            )
+        )
+
+        class FallbackTree:
+            def get_terminals(self):
+                return [SimpleNamespace(name="b")]
+
+        monkeypatch.setattr(
+            Tree,
+            "_scan_simple_newick_tip_names",
+            staticmethod(lambda _path: None),
+        )
+        monkeypatch.setattr(
+            Tree,
+            "calculate_terminal_names_fast",
+            staticmethod(lambda _tree: None),
+        )
+        monkeypatch.setattr(Phylo, "read", lambda *_args: FallbackTree())
+
+        order, labels = service._determine_order(
+            np.eye(3),
+            ["a", "b", "c"],
+            3,
+        )
+
+        assert order == [1, 0, 2]
+        assert labels == ["b", "a", "c"]
+
+    def test_p_distance_clustering_returns_complete_order(self, tmp_path):
+        service = IdentityMatrix(
+            _make_args(
+                "aln.fa",
+                tmp_path / "out.png",
+                sort="cluster",
+                metric="p-distance",
+            )
+        )
+        distance_matrix = np.array(
+            [
+                [0.0, 0.1, 0.8],
+                [0.1, 0.0, 0.7],
+                [0.8, 0.7, 0.0],
+            ]
+        )
+
+        order, labels, cluster = service._determine_order(
+            distance_matrix,
+            ["a", "b", "c"],
+            3,
+            return_linkage=True,
+        )
+
+        assert sorted(order) == [0, 1, 2]
+        assert sorted(labels) == ["a", "b", "c"]
+        assert cluster is not None
+
+    def test_plot_heatmap_simple_layout_with_partition_strip(self, tmp_path):
+        output = tmp_path / "simple.png"
+        service = IdentityMatrix(
+            _make_args(
+                "aln.fa",
+                output,
+                sort="alpha",
+                no_title=True,
+                ylabel_fontsize=0,
+                axis_fontsize=8,
+            )
+        )
+        service.plot_config.ylabel_fontsize = 0
+        service.plot_config.show_title = False
+        sequences = {"a": "ACGT", "b": "ACGA"}
+
+        service._plot_heatmap(
+            np.array([[1.0, 0.75], [0.75, 1.0]]),
+            ["a", "b"],
+            [0, 1],
+            ["a", "b"],
+            2,
+            partitions=[("gene", 0, 4)],
+            sequences=sequences,
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_plot_heatmap_builds_p_distance_linkage_when_missing(self, tmp_path):
+        output = tmp_path / "cluster.png"
+        service = IdentityMatrix(
+            _make_args(
+                "aln.fa",
+                output,
+                sort="cluster",
+                metric="p-distance",
+            )
+        )
+        distance_matrix = np.array(
+            [
+                [0.0, 0.1, 0.8],
+                [0.1, 0.0, 0.7],
+                [0.8, 0.7, 0.0],
+            ]
+        )
+
+        service._plot_heatmap(
+            distance_matrix,
+            ["a", "b", "c"],
+            [0, 1, 2],
+            ["a", "b", "c"],
+            3,
+            cluster_linkage=None,
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_plot_heatmap_reports_missing_matplotlib(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        original_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("matplotlib"):
+                raise ImportError("matplotlib unavailable")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        service = IdentityMatrix(_make_args("aln.fa", tmp_path / "out.png"))
+
+        with pytest.raises(SystemExit) as exc_info:
+            service._plot_heatmap(
+                np.eye(2),
+                ["a", "b"],
+                [0, 1],
+                ["a", "b"],
+                2,
+            )
+
+        assert exc_info.value.code == 2
+        assert "matplotlib is required for identity_matrix" in (
+            capsys.readouterr().err
+        )

--- a/tests/unit/services/alignment/test_pairwise_identity_service.py
+++ b/tests/unit/services/alignment/test_pairwise_identity_service.py
@@ -156,6 +156,93 @@ def test_small_value_summary_matches_shared_helper():
     ) == pytest.approx(calculate_summary_statistics_from_arr(values))
 
 
+def test_pairwise_identity_helper_edge_cases():
+    assert pairwise_identity_module._pair_ids_follow_taxa_upper_triangle(
+        ["a", "b", "c"],
+        [["a", "b"]],
+    ) is False
+    assert pairwise_identity_module._alignment_size(iter(())) is None
+    assert pairwise_identity_module._all_sequences_identical([]) is True
+    assert pairwise_identity_module._identity_for_identical_sequence(
+        "", False, True
+    ) == 0.0
+    assert pairwise_identity_module._identity_for_identical_sequence(
+        "AΩ-", False, True
+    ) == pytest.approx(2 / 3)
+
+    counts = np.zeros((2, 2), dtype=np.float32)
+    np.testing.assert_array_equal(
+        pairwise_identity_module._identity_values_from_count_matrix(counts, 0),
+        np.array([0.0]),
+    )
+    assert pairwise_identity_module._linear_percentile([0.2, 0.8], 1.0) == 0.8
+
+    empty_stats = pairwise_identity_module._summary_statistics_from_small_values([])
+    constant_stats = pairwise_identity_module._summary_statistics_from_small_values(
+        [0.75, 0.75, 0.75]
+    )
+    assert empty_stats is None
+    assert constant_stats["mean"] == 0.75
+    assert constant_stats["variance"] == 0.0
+    assert pairwise_identity_module._constant_identity_stats(0.5, 1) is None
+
+    matrix = np.full((2, 3), ord("A"), dtype=np.uint8)
+    observed = _clean_nucleotide_identity_counts(
+        matrix,
+        matrix.tobytes(),
+        is_protein=False,
+    )
+    np.testing.assert_array_equal(observed, np.full((2, 2), 3.0))
+
+
+def test_lazy_multiprocessing_pool_delegates_to_cached_module():
+    lazy_mp = pairwise_identity_module._LazyMultiprocessing()
+    sentinel = object()
+
+    with patch.object(multiprocessing, "Pool", return_value=sentinel) as pool:
+        assert lazy_mp.Pool(processes=3) is sentinel
+
+    pool.assert_called_once_with(processes=3)
+    assert lazy_mp._module is multiprocessing
+
+
+def test_print_summary_statistics_ignores_broken_pipe(mocker):
+    mocked_print = mocker.patch("builtins.print", side_effect=BrokenPipeError)
+
+    pairwise_identity_module.print_summary_statistics(
+        {
+            "mean": 0.5,
+            "median": 0.5,
+            "twenty_fifth": 0.25,
+            "seventy_fifth": 0.75,
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "standard_deviation": 0.1,
+            "variance": 0.01,
+        }
+    )
+
+    mocked_print.assert_called_once()
+
+
+def test_tqdm_returns_iterable_when_optional_dependency_is_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tqdm":
+            raise ImportError("tqdm unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    values = [1, 2, 3]
+
+    assert pairwise_identity_module.tqdm(values) is values
+
+
+def test_tqdm_delegates_when_optional_dependency_is_available():
+    assert list(pairwise_identity_module.tqdm([1, 2], disable=True)) == [1, 2]
+
+
 def test_module_import_does_not_import_scipy_clustering(monkeypatch):
     module_name = "phykit.services.alignment.pairwise_identity"
     previous = sys.modules.pop(module_name, None)
@@ -1342,3 +1429,245 @@ assert "phykit.helpers.plot_config" not in sys.modules
         assert len(identities) == 2080
         assert 0.0 <= stats["mean"] <= 1.0
         mocked_pool.assert_not_called()
+
+    def test_scalar_helpers_cover_empty_oversized_and_uneven_inputs(
+        self, monkeypatch
+    ):
+        one_record = [SimpleNamespace(id="a", seq="ACGT")]
+        uneven_records = [
+            SimpleNamespace(id="a", seq="ACGT"),
+            SimpleNamespace(id="b", seq="ACG"),
+        ]
+        empty_records = [
+            SimpleNamespace(id="a", seq=""),
+            SimpleNamespace(id="b", seq=""),
+        ]
+
+        assert pairwise_identity_module._pairwise_identity_stats_scalar(
+            one_record, False, False
+        ) is None
+        assert pairwise_identity_module._pairwise_identities_scalar(
+            one_record, False, False
+        ) is None
+        assert pairwise_identity_module._pairwise_identities_scalar(
+            uneven_records, False, False
+        ) is None
+
+        monkeypatch.setattr(
+            pairwise_identity_module,
+            "_PAIRWISE_IDENTITY_SCALAR_STATS_MAX_CELLS",
+            1,
+        )
+        monkeypatch.setattr(
+            pairwise_identity_module,
+            "_PAIRWISE_IDENTITY_SCALAR_RESULT_MAX_CELLS",
+            1,
+        )
+        records = [
+            SimpleNamespace(id="a", seq="AA"),
+            SimpleNamespace(id="b", seq="AT"),
+        ]
+        assert pairwise_identity_module._pairwise_identity_stats_scalar(
+            records, False, False
+        ) is None
+        assert pairwise_identity_module._pairwise_identities_scalar(
+            records, False, False
+        ) is None
+
+        empty_result = pairwise_identity_module._pairwise_identities_scalar(
+            empty_records, False, False
+        )
+        assert empty_result[1] == {"a-b": 0.0}
+        assert empty_result[2] is None
+
+    def test_matrix_helpers_reject_invalid_and_unicode_alignments(self, args):
+        service = PairwiseIdentity(args)
+        one_record = [SimpleNamespace(id="a", seq="ACGT")]
+        uneven_records = [
+            SimpleNamespace(id="a", seq="ACGT"),
+            SimpleNamespace(id="b", seq="ACG"),
+        ]
+        unicode_records = [
+            SimpleNamespace(id="a", seq="AΩGT"),
+            SimpleNamespace(id="b", seq="TΩGT"),
+        ]
+
+        for records in (one_record, uneven_records, unicode_records):
+            assert service._calculate_pairwise_identities_matrix(
+                records, False, False
+            ) is None
+            assert service._calculate_pairwise_identity_stats_matrix(
+                records, False, False
+            ) is None
+
+    def test_protein_gap_lookup_and_unicode_gap_array(self, args):
+        service = PairwiseIdentity(args)
+        PairwiseIdentity._PROTEIN_GAP_LOOKUP = None
+
+        lookup = service._get_gap_lookup(is_protein=True)
+        unicode_sequence = service._sequence_to_array("AΩ-")
+        unicode_gaps = service._gap_chars_array_for_sequence(
+            unicode_sequence,
+            {"-", "Ω"},
+        )
+        byte_sequence = service._sequence_to_array("AC-")
+        unicode_fallback_gaps = service._gap_chars_array_for_sequence(
+            byte_sequence,
+            {"Ω"},
+        )
+
+        assert lookup[ord("-")]
+        assert lookup[ord("X")]
+        assert not lookup[ord("N")]
+        assert unicode_gaps.dtype.kind == "U"
+        assert unicode_fallback_gaps.dtype.kind == "U"
+        assert np.isin(unicode_sequence, unicode_gaps).tolist() == [
+            False,
+            True,
+            True,
+        ]
+
+    def test_process_pair_batch_builds_missing_gap_masks(self, args):
+        service = PairwiseIdentity(args)
+        alignment_data = [
+            {"id": "a", "seq": service._sequence_to_array("AC-T")},
+            {"id": "b", "seq": service._sequence_to_array("ACGT")},
+        ]
+
+        result = service._process_pair_batch(
+            alignment_data,
+            [(0, 1)],
+            exclude_gaps=True,
+            gap_chars={"-", "?", "*", "X", "N"},
+        )
+
+        assert result == [{"pair_id": ["a", "b"], "identity": 0.75}]
+
+    def test_stats_matrix_protein_fallback_matches_full_result(self, args):
+        service = PairwiseIdentity(args)
+        records = [
+            SimpleNamespace(id="a", seq="ARND"),
+            SimpleNamespace(id="b", seq="ARNE"),
+            SimpleNamespace(id="c", seq="TRNE"),
+        ]
+
+        stats = service._calculate_pairwise_identity_stats_matrix(
+            records,
+            is_protein=True,
+            exclude_gaps=False,
+        )
+        expected = pairwise_identity_module._pairwise_identities_scalar(
+            records,
+            is_protein=True,
+            exclude_gaps=False,
+        )[2]
+
+        assert stats == pytest.approx(expected)
+
+    @pytest.mark.parametrize("stderr_is_tty", [False, True])
+    def test_unicode_fallback_reaches_multiprocessing_backend(
+        self, args, mocker, monkeypatch, stderr_is_tty
+    ):
+        class ReiterableWithoutLength:
+            def __init__(self, records):
+                self.records = records
+
+            def __iter__(self):
+                return iter(self.records)
+
+            def __len__(self):
+                raise TypeError("length unavailable")
+
+        class FakePool:
+            def __init__(self, processes):
+                self.processes = processes
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def map(self, process_func, chunks):
+                return [process_func(chunk) for chunk in chunks]
+
+            def imap(self, process_func, chunks):
+                return (process_func(chunk) for chunk in chunks)
+
+        records = ReiterableWithoutLength(
+            [
+                SimpleNamespace(id="a", seq="AΩAA"),
+                SimpleNamespace(id="b", seq="AΩAT"),
+                SimpleNamespace(id="c", seq="CΩAT"),
+            ]
+        )
+        service = PairwiseIdentity(args)
+        mocker.patch.object(
+            PairwiseIdentity,
+            "_should_use_multiprocessing",
+            return_value=True,
+        )
+        mocker.patch(
+            "phykit.services.alignment.pairwise_identity.mp.Pool",
+            FakePool,
+        )
+        mocker.patch(
+            "phykit.services.alignment.pairwise_identity.mp.cpu_count",
+            return_value=2,
+        )
+        progress_calls = []
+        mocker.patch(
+            "phykit.services.alignment.pairwise_identity.tqdm",
+            side_effect=lambda iterable, **kwargs: (
+                progress_calls.append(kwargs) or iterable
+            ),
+        )
+        monkeypatch.setattr(
+            pairwise_identity_module.sys.stderr,
+            "isatty",
+            lambda: stderr_is_tty,
+        )
+
+        pair_ids, identities, stats = service.calculate_pairwise_identities(
+            records,
+            exclude_gaps=False,
+            is_protein=False,
+        )
+
+        assert pair_ids == [["a", "b"], ["a", "c"], ["b", "c"]]
+        assert identities == {"a-b": 0.75, "a-c": 0.5, "b-c": 0.75}
+        assert stats["mean"] == pytest.approx(2 / 3)
+        assert bool(progress_calls) is stderr_is_tty
+        if stderr_is_tty:
+            assert progress_calls[0]["total"] == 3
+
+    def test_stats_unicode_fallback_matches_pairwise_results(
+        self, args, mocker
+    ):
+        class ReiterableWithoutLength:
+            def __iter__(self):
+                return iter(
+                    [
+                        SimpleNamespace(id="a", seq="AΩAA"),
+                        SimpleNamespace(id="b", seq="AΩAT"),
+                        SimpleNamespace(id="c", seq="CΩAT"),
+                    ]
+                )
+
+            def __len__(self):
+                raise TypeError("length unavailable")
+
+        service = PairwiseIdentity(args)
+        mocker.patch.object(
+            PairwiseIdentity,
+            "_should_use_multiprocessing",
+            return_value=False,
+        )
+
+        stats = service.calculate_pairwise_identity_stats(
+            ReiterableWithoutLength(),
+            exclude_gaps=False,
+            is_protein=False,
+        )
+
+        assert stats["mean"] == pytest.approx(2 / 3)

--- a/tests/unit/services/alignment/test_phylo_gwas.py
+++ b/tests/unit/services/alignment/test_phylo_gwas.py
@@ -2229,3 +2229,319 @@ class TestPhyloGwas:
         )
 
         assert result is None
+
+    def test_statistical_helpers_cover_boundaries_and_vector_bh(self, monkeypatch):
+        from scipy.special import chdtrc
+
+        assert phylo_gwas_module._bounded_ascii_count_dtype(0xFFFF) is np.uint16
+        assert phylo_gwas_module._bounded_ascii_count_dtype(0x10000) is np.uint32
+        assert phylo_gwas_module._bounded_ascii_count_dtype(
+            0x100000000
+        ) is np.uint64
+        assert phylo_gwas_module._chi2_sf_integer_df(0, 4.0) == 1.0
+
+        monkeypatch.setattr(phylo_gwas_module, "_CHDTRC", None)
+        observed = phylo_gwas_module._chi2_sf_integer_df(10, 4.0)
+        assert observed == pytest.approx(float(chdtrc(10, 4.0)))
+        assert phylo_gwas_module._CHDTRC is not None
+
+        cache = {}
+        assert phylo_gwas_module._fisher_exact_2x2_counts(
+            0, 0, 0, 0, cache
+        ) == 1.0
+        assert cache[(0, 0, 0, 0)] == 1.0
+
+        p_values = [0.04, 0.01, 0.20, 0.03, 0.8, 0.5, 0.002, 0.9]
+        adjusted = PhyloGwas._benjamini_hochberg(p_values)
+        scalar_reference = []
+        for index, p_value in enumerate(p_values):
+            rank = 1 + sum(value < p_value for value in p_values)
+            candidates = [
+                value * len(p_values) / (1 + offset)
+                for offset, value in enumerate(sorted(p_values))
+                if offset + 1 >= rank
+            ]
+            scalar_reference.append(min(1.0, min(candidates)))
+        np.testing.assert_allclose(adjusted, scalar_reference)
+
+    def test_ascii_prefilter_and_allele_helpers_cover_empty_and_sampled_inputs(self):
+        valid_empty = np.zeros(4, dtype=bool)
+        assert PhyloGwas._should_prefilter_biallelic_ascii_columns(
+            np.empty((3, 4), dtype=np.uint8),
+            valid_empty,
+        ) is False
+
+        column = np.array([ord("A"), ord("A"), ord("G"), ord("G")], dtype=np.uint8)
+        matrix = np.tile(column[:, None], (1, 600))
+        assert PhyloGwas._should_prefilter_biallelic_ascii_columns(
+            matrix,
+            np.ones(600, dtype=bool),
+        ) is False
+
+        assert PhyloGwas._major_minor_bytes(np.array([], dtype=np.uint8)) is None
+        assert PhyloGwas._major_minor_bytes(
+            np.array([ord("A"), ord("G"), ord("G")], dtype=np.uint8)
+        ) == (ord("G"), ord("A"), 1)
+        group_codes = np.array([0, 0, 1], dtype=np.intp)
+        assert PhyloGwas._major_minor_two_group_counts(
+            np.array([], dtype=np.uint8), group_codes[:0]
+        ) is None
+        assert PhyloGwas._major_minor_two_group_counts(
+            np.array([ord("A"), ord("A"), ord("A")], dtype=np.uint8),
+            group_codes,
+        ) is None
+        assert PhyloGwas._major_minor_two_group_counts(
+            np.array([ord("A"), ord("C"), ord("G")], dtype=np.uint8),
+            group_codes,
+        ) is None
+        assert PhyloGwas._major_minor_two_group_counts(
+            np.array([ord("A"), ord("G"), ord("G")], dtype=np.uint8),
+            group_codes,
+        ) == (ord("G"), ord("A"), (1, 0))
+
+    def test_categorical_degenerate_groups_and_late_unicode_fallback(self):
+        service = PhyloGwas.__new__(PhyloGwas)
+        assert service._starts_with_non_ascii_allele([]) is False
+
+        result = service._test_site_categorical(
+            ["A", "Ω", "A", "Ω"],
+            ["x", "x", "y", "y"],
+            ["x", "y"],
+        )
+        assert result is not None
+        assert {result[1], result[2]} == {"A", "Ω"}
+
+        assert service._test_site_categorical(
+            ["A", "G"],
+            ["x", "y"],
+            ["x", "y", "missing"],
+        ) is None
+
+        one_group = service._test_site_categorical(
+            ["A", "A", "G", "G"],
+            ["x", "x", "x", "x"],
+            ["x"],
+        )
+        assert one_group[0] == 1.0
+
+    def test_continuous_degenerate_perfect_and_nan_results(self):
+        service = PhyloGwas.__new__(PhyloGwas)
+        assert service._test_site_continuous(
+            ["A", "A", "G", "G"],
+            [1.0, 1.0, 1.0, 1.0],
+        ) is None
+
+        perfect = service._test_site_continuous(
+            ["A", "A", "G", "G"],
+            [1.0, 1.0, 2.0, 2.0],
+        )
+        assert perfect[0] == 0.0
+        assert abs(perfect[3]) == 1.0
+
+        late_unicode = service._test_site_continuous(
+            ["A", "Ω", "A", "Ω"],
+            [1.0, 3.0, 2.0, 4.0],
+        )
+        assert late_unicode is not None
+
+        nan_result = service._test_site_continuous(
+            ["A", "A", "G", "G"],
+            [1.0, 2.0, 3.0, 4.0],
+            phenotype_centered=np.full(4, np.nan),
+            phenotype_ss=1.0,
+        )
+        assert np.isnan(nan_result[0])
+        assert np.isnan(nan_result[3])
+
+    def test_phylo_pattern_legacy_traversal_and_error_fallbacks(self):
+        class Clade:
+            def __init__(self, name=None, children=None):
+                self.name = name
+                self.clades = children or []
+
+            def is_terminal(self):
+                return not self.clades
+
+        a = Clade("a")
+        b = Clade("b")
+        root = Clade(children=[a, b])
+
+        class LegacyTree:
+            def find_clades(self, order=None):
+                assert order == "postorder"
+                return [a, b, root]
+
+            def get_terminals(self):
+                return [a, b]
+
+            def common_ancestor(self, _taxa):
+                raise ValueError("unknown taxon")
+
+        tree = LegacyTree()
+        patterns = PhyloGwas._build_phylo_pattern_index(tree)
+
+        assert frozenset({"a", "b"}) in patterns
+        assert PhyloGwas._terminal_clades(tree) == [a, b]
+        assert PhyloGwas._classify_phylo_pattern(
+            tree,
+            ["a", "missing"],
+        ) == "polyphyletic"
+
+    def test_run_rejects_unequal_alignment_lengths(self, tmp_path, capsys):
+        args = _make_args(
+            tmp_path,
+            seqs={
+                "a": "AA",
+                "b": "AA",
+                "c": "AA",
+                "d": "A",
+            },
+            pheno={"a": "x", "b": "x", "c": "y", "d": "y"},
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            PhyloGwas(args).run()
+
+        assert exc_info.value.code == 2
+        assert "sequences have unequal lengths" in capsys.readouterr().out
+
+    def test_unicode_run_skips_invalid_sites_and_marks_tree_nonsignificant(
+        self, tmp_path, monkeypatch
+    ):
+        seqs = {
+            "a": "AΩ-α",
+            "b": "AΩAβ",
+            "c": "AΨAγ",
+            "d": "AΨAα",
+        }
+        pheno = {"a": "x", "b": "x", "c": "y", "d": "y"}
+        args = _make_args(
+            tmp_path,
+            seqs=seqs,
+            pheno=pheno,
+            tree="((a,b),(c,d));",
+            alpha=0.0,
+        )
+        service = PhyloGwas(args)
+        captured = {}
+        monkeypatch.setattr(service, "_create_manhattan_plot", lambda *_args: None)
+
+        def capture_text(*call_args):
+            captured["site_results"] = call_args[6]
+
+        monkeypatch.setattr(service, "_print_text_output", capture_text)
+
+        service.run()
+
+        assert captured["site_results"]
+        assert all(
+            result["phylo_pattern"] is None
+            for result in captured["site_results"]
+        )
+
+    def test_continuous_run_skips_site_without_phenotype_variance(
+        self, tmp_path, monkeypatch
+    ):
+        args = _make_args(
+            tmp_path,
+            seqs={"a": "A", "b": "A", "c": "G", "d": "G"},
+            pheno={"a": "1", "b": "1", "c": "1", "d": "1"},
+        )
+        service = PhyloGwas(args)
+        monkeypatch.setattr(service, "_create_manhattan_plot", lambda *_args: None)
+        captured = {}
+        monkeypatch.setattr(
+            service,
+            "_print_text_output",
+            lambda *call_args: captured.setdefault("site_results", call_args[6]),
+        )
+
+        service.run()
+
+        assert captured["site_results"] == []
+
+    def test_continuous_significant_text_and_broken_pipe(self, tmp_path, mocker):
+        service = PhyloGwas(_make_args(tmp_path, pheno=PHENO_CONTINUOUS))
+        result = {
+            "position": 2,
+            "gene": None,
+            "allele_0": "A",
+            "allele_1": "G",
+            "correlation_r": 0.9,
+            "p_value": 0.001,
+            "fdr_p_value": 0.002,
+            "fdr_significant": True,
+            "phylo_pattern": None,
+        }
+        mocked_print = mocker.patch("builtins.print")
+
+        service._print_text_output(
+            8, 5, "continuous", True, [], None, [result], [result], 0, 0, False
+        )
+        assert "Top significant sites" in mocked_print.call_args.args[0]
+
+        mocked_print.side_effect = BrokenPipeError
+        service._print_text_output(
+            8, 5, "continuous", True, [], None, [result], [result], 0, 0, False
+        )
+
+    def test_empty_plot_missing_matplotlib_and_cache_edges(
+        self, tmp_path, monkeypatch
+    ):
+        service = PhyloGwas(_make_args(tmp_path))
+        service._create_manhattan_plot([], [], False)
+        assert Path(service.output_path).stat().st_size > 0
+
+        empty_key = service._manhattan_plot_cache_key([], [], False)
+        assert empty_key[0] == "empty"
+        monkeypatch.setattr(
+            phylo_gwas_module,
+            "_MANHATTAN_PLOT_CACHE_MAX_ROWS",
+            1,
+        )
+        assert service._manhattan_plot_cache_key(
+            [{"position": 1}, {"position": 2}], [], False
+        ) is None
+        service._store_manhattan_plot_cache(None)
+
+        rendered_output = service.output_path
+        service.output_path = str(tmp_path / "absent.png")
+        service._store_manhattan_plot_cache(("missing",))
+        service.output_path = rendered_output
+
+        phylo_gwas_module._MANHATTAN_PLOT_CACHE.clear()
+        phylo_gwas_module._MANHATTAN_PLOT_CACHE[("old",)] = b"old"
+        monkeypatch.setattr(phylo_gwas_module, "_MANHATTAN_PLOT_CACHE_MAX", 1)
+        service._store_manhattan_plot_cache(empty_key)
+        assert ("old",) not in phylo_gwas_module._MANHATTAN_PLOT_CACHE
+
+    def test_plot_reports_missing_matplotlib(self, tmp_path, monkeypatch, capsys):
+        service = PhyloGwas(_make_args(tmp_path))
+        original_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("matplotlib"):
+                raise ImportError("matplotlib unavailable")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(SystemExit) as exc_info:
+            service._create_manhattan_plot(
+                [{"position": 1, "p_value": 0.5, "fdr_significant": False}],
+                [],
+                False,
+            )
+
+        assert exc_info.value.code == 2
+        assert "matplotlib is required for phylo_gwas" in capsys.readouterr().out
+
+    def test_write_continuous_csv_accepts_incomplete_rows(self, tmp_path):
+        csv_path = tmp_path / "incomplete.csv"
+        service = PhyloGwas(_make_args(tmp_path, csv=str(csv_path)))
+
+        service._write_csv([{"position": 1}], is_continuous=True)
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[1][0] == "1"
+        assert rows[1][4] == ""

--- a/tests/unit/services/tree/test_ancestral_reconstruction.py
+++ b/tests/unit/services/tree/test_ancestral_reconstruction.py
@@ -1899,6 +1899,53 @@ class TestRun:
             "D",
         ]
 
+    def test_continuous_output_omits_unlabeled_and_unestimated_nodes(
+        self, default_args, mocker
+    ):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        left, _ = tree.root.clades
+        node_labels = {id(tree.root): "root", id(left): "left"}
+        node_estimates = {"root": 1.5}
+
+        result = svc._format_result(
+            method="fast",
+            trait_name="trait",
+            n_tips=4,
+            sigma2=1.0,
+            log_likelihood=-1.0,
+            node_estimates=node_estimates,
+            node_cis={},
+            node_labels=node_labels,
+            tree=tree,
+            trait_values={"A": 1.0, "B": 1.0, "C": 2.0, "D": 2.0},
+        )
+
+        assert result["ancestral_estimates"] == {
+            "root": {
+                "estimate": 1.5,
+                "descendants": ["A", "B", "C", "D"],
+                "is_root": True,
+            }
+        }
+
+        mocked_print = mocker.patch("builtins.print")
+        for node_cis in ({}, {"root": (1.0, 2.0)}):
+            svc._print_text_output(
+                method="fast",
+                trait_name="trait",
+                n_tips=4,
+                sigma2=1.0,
+                log_likelihood=-1.0,
+                node_estimates=node_estimates,
+                node_cis=node_cis,
+                node_labels=node_labels,
+                tree=tree,
+            )
+
+        assert mocked_print.call_count == 2
+        assert all("left" not in call.args[0] for call in mocked_print.call_args_list)
+
     @patch("builtins.print")
     def test_multi_trait_run(self, mocked_print, multi_trait_args):
         svc = AncestralReconstruction(multi_trait_args)
@@ -1949,6 +1996,49 @@ class TestPlot:
         assert values.iterations == 1
         assert _value_range([]) is None
         assert _value_range([2.0, 2.0]) == (2.0, 2.0)
+
+    def test_contmap_returns_without_estimates(self, default_args, tmp_path):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        output_path = tmp_path / "empty.png"
+
+        svc._plot_contmap(
+            tree,
+            node_estimates={},
+            node_labels={},
+            trait_values={},
+            trait_name="trait",
+            output_path=str(output_path),
+        )
+
+        assert not output_path.exists()
+
+    def test_contmap_reports_missing_matplotlib(
+        self, default_args, monkeypatch, capsys, tmp_path
+    ):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        original_import = builtins.__import__
+
+        def reject_matplotlib(name, *args, **kwargs):
+            if name == "matplotlib" or name.startswith("matplotlib."):
+                raise ImportError("matplotlib unavailable")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", reject_matplotlib)
+
+        with pytest.raises(SystemExit) as excinfo:
+            svc._plot_contmap(
+                tree,
+                node_estimates={"root": 1.0},
+                node_labels={id(tree.root): "root"},
+                trait_values={"A": 1.0, "B": 2.0, "C": 3.0},
+                trait_name="trait",
+                output_path=str(tmp_path / "plot.png"),
+            )
+
+        assert excinfo.value.code == 2
+        assert "matplotlib is required for contMap plotting" in capsys.readouterr().out
 
     @pytest.mark.parametrize("circular", [False, True])
     def test_contmap_plot_uses_direct_tree_traversal(
@@ -2682,6 +2772,38 @@ class TestDiscreteTraitParsing:
                 str(trait_file), ["raccoon", "bear", "weasel"]
             )
 
+    def test_single_col_reports_taxon_mismatches(
+        self, discrete_args, tmp_path, capsys
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        trait_file = tmp_path / "states.tsv"
+        trait_file.write_text("A\tx\nB\tx\nC\ty\nX\ty\n")
+
+        traits = svc._parse_discrete_trait_data_single(
+            str(trait_file), ["A", "B", "C", "D"]
+        )
+
+        assert traits == {"A": "x", "B": "x", "C": "y"}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: D",
+            "Warning: 1 taxa in trait file but not in tree: X",
+        ]
+
+    def test_single_col_requires_three_shared_taxa(self, discrete_args, tmp_path):
+        svc = AncestralReconstruction(discrete_args)
+        trait_file = tmp_path / "states.tsv"
+        trait_file.write_text("A\tx\nB\tx\nX\ty\n")
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_discrete_trait_data_single(
+                str(trait_file), ["A", "B", "C"]
+            )
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
+
     def test_missing_column_error(self, discrete_args):
         svc = AncestralReconstruction(discrete_args)
         tree = svc.read_tree_file()
@@ -2787,6 +2909,79 @@ class TestDiscreteTraitParsing:
                 ["raccoon", "bear", "weasel"],
                 "activity",
             )
+
+    @pytest.mark.parametrize(
+        ("contents", "expected_message"),
+        [
+            (
+                "# comment only\n\n",
+                "Multi-trait file must have a header row and at least one data row.",
+            ),
+            (
+                "taxon\nA\n",
+                "Header must have at least 2 columns (taxon + at least 1 trait).",
+            ),
+            (
+                "taxon\tdiet\n",
+                "Multi-trait file must have a header row and at least one data row.",
+            ),
+        ],
+    )
+    def test_multi_col_rejects_invalid_files(
+        self, discrete_args, tmp_path, contents, expected_message
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        trait_file = tmp_path / "states.tsv"
+        trait_file.write_text(contents)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_discrete_trait_data_multi(
+                str(trait_file), ["A", "B", "C"], "diet"
+            )
+
+        assert expected_message in excinfo.value.messages
+
+    def test_multi_col_reports_taxon_mismatches(
+        self, discrete_args, tmp_path, capsys
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        trait_file = tmp_path / "states.tsv"
+        trait_file.write_text("taxon\tdiet\nA\tx\nB\tx\nC\ty\nX\ty\n")
+
+        traits = svc._parse_discrete_trait_data_multi(
+            str(trait_file), ["A", "B", "C", "D"], "diet"
+        )
+
+        assert traits == {"A": "x", "B": "x", "C": "y"}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: D",
+            "Warning: 1 taxa in trait file but not in tree: X",
+        ]
+
+    def test_multi_col_requires_three_shared_taxa(self, discrete_args, tmp_path):
+        svc = AncestralReconstruction(discrete_args)
+        trait_file = tmp_path / "states.tsv"
+        trait_file.write_text("taxon\tdiet\nA\tx\nB\tx\nX\ty\n")
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_discrete_trait_data_multi(
+                str(trait_file), ["A", "B", "C"], "diet"
+            )
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
+
+    def test_multi_col_file_not_found(self, discrete_args, tmp_path):
+        svc = AncestralReconstruction(discrete_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_discrete_trait_data_multi(
+                str(tmp_path / "missing.tsv"), ["A", "B", "C"], "diet"
+            )
+
+        assert "corresponds to no such file or directory" in excinfo.value.messages[0]
 
     def test_file_not_found(self, discrete_args):
         svc = AncestralReconstruction(discrete_args)
@@ -2959,6 +3154,58 @@ class TestDiscreteMarginalPosteriors:
         for node_id in expected:
             np.testing.assert_allclose(observed[node_id], expected[node_id])
 
+    def test_discrete_posteriors_fall_back_when_direct_preorder_fails(
+        self, discrete_args, monkeypatch
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        tip_states = {"A": "x", "B": "x", "C": "y"}
+        states = ["x", "y"]
+        Q = np.array([[-1.0, 1.0], [1.0, -1.0]])
+        expected = svc._discrete_marginal_posteriors(tree, tip_states, Q, states)
+        original_iter_preorder = svc._iter_preorder
+        call_count = 0
+
+        def fail_first_preorder(root):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AttributeError("direct traversal unavailable")
+            return original_iter_preorder(root)
+
+        monkeypatch.setattr(svc, "_iter_preorder", fail_first_preorder)
+
+        observed = svc._discrete_marginal_posteriors(tree, tip_states, Q, states)
+
+        assert observed.keys() == expected.keys()
+        for node_id in expected:
+            np.testing.assert_allclose(observed[node_id], expected[node_id])
+
+    def test_discrete_posteriors_use_uniform_fallback_for_zero_likelihoods(
+        self, discrete_args, mocker
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        clades = list(svc._iter_preorder(tree.root))
+        zero_likelihoods = {id(clade): np.zeros(2) for clade in clades}
+        mocker.patch.object(
+            svc,
+            "_felsenstein_pruning",
+            return_value=(zero_likelihoods, float("-inf")),
+        )
+        mocker.patch.object(svc, "_matrix_exp", return_value=np.eye(2))
+
+        posteriors = svc._discrete_marginal_posteriors(
+            tree,
+            {"A": "x", "B": "x", "C": "y"},
+            np.array([[-1.0, 1.0], [1.0, -1.0]]),
+            ["x", "y"],
+        )
+
+        assert posteriors
+        for posterior in posteriors.values():
+            np.testing.assert_array_equal(posterior, [0.5, 0.5])
+
 
 class TestDiscreteRun:
     @patch("builtins.print")
@@ -3113,6 +3360,34 @@ class TestDiscreteRun:
         prune.assert_called_once_with(tree_copy, ["D"])
         assert fit_q.call_args.args[0] is pruned_tree
 
+    def test_discrete_run_supports_single_column_traits_and_ladderizing(
+        self, discrete_args, mocker
+    ):
+        discrete_args.trait = None
+        discrete_args.ladderize = True
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        tree_copy = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        states_by_tip = {"A": "x", "B": "x", "C": "y", "D": "y"}
+        parse_single = mocker.patch.object(
+            svc, "_parse_discrete_trait_data_single", return_value=states_by_tip
+        )
+        mocker.patch.object(svc, "_fast_copy", return_value=tree_copy)
+        ladderize = mocker.spy(tree_copy, "ladderize")
+        mocker.patch.object(svc, "_label_internal_nodes", return_value={})
+        mocker.patch.object(svc, "_fit_q_matrix", return_value=(np.eye(2), -1.0))
+        mocker.patch.object(svc, "_discrete_marginal_posteriors", return_value={})
+        format_result = mocker.patch.object(
+            svc, "_format_discrete_result", return_value={"ok": True}
+        )
+        mocker.patch.object(svc, "_print_discrete_text_output")
+
+        svc._run_discrete(tree, ["A", "B", "C", "D"])
+
+        parse_single.assert_called_once()
+        ladderize.assert_called_once_with()
+        assert format_result.call_args.kwargs["trait_name"] == "trait"
+
     def test_discrete_text_output_uses_cached_descendant_counts(
         self, discrete_args, monkeypatch, mocker
     ):
@@ -3212,6 +3487,49 @@ class TestDiscreteRun:
             "C",
             "D",
         ]
+
+    def test_discrete_output_omits_unlabeled_and_unestimated_nodes(
+        self, discrete_args, mocker
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        left, _ = tree.root.clades
+        node_labels = {id(tree.root): "root", id(left): "left"}
+        node_posteriors = {id(tree.root): np.array([0.25, 0.75])}
+        states = ["x", "y"]
+        Q = np.array([[-1.0, 1.0], [1.0, -1.0]])
+
+        result = svc._format_discrete_result(
+            model="ER",
+            trait_name="trait",
+            n_tips=4,
+            log_likelihood=-1.0,
+            states=states,
+            Q=Q,
+            node_posteriors=node_posteriors,
+            node_labels=node_labels,
+            tree=tree,
+            tip_states={"A": "x", "B": "x", "C": "y", "D": "y"},
+        )
+
+        assert list(result["ancestral_states"]) == ["root"]
+
+        mocked_print = mocker.patch("builtins.print")
+        svc._print_discrete_text_output(
+            model="ER",
+            trait_name="trait",
+            n_tips=4,
+            log_likelihood=-1.0,
+            states=states,
+            Q=Q,
+            node_posteriors=node_posteriors,
+            node_labels=node_labels,
+            tree=tree,
+        )
+
+        output = mocked_print.call_args.args[0]
+        assert "root (root)" in output
+        assert "left" not in output
 
     @patch("builtins.print")
     def test_continuous_regression(self, mocked_print):
@@ -3375,6 +3693,123 @@ class TestDiscretePlot:
         )
 
         assert second_path.read_bytes() == first_bytes
+
+    def test_discrete_plot_reports_missing_matplotlib(
+        self, discrete_args, monkeypatch, capsys, tmp_path
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        original_import = builtins.__import__
+
+        def reject_matplotlib(name, *args, **kwargs):
+            if name == "matplotlib" or name.startswith("matplotlib."):
+                raise ImportError("matplotlib unavailable")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", reject_matplotlib)
+
+        with pytest.raises(SystemExit) as excinfo:
+            svc._plot_discrete_asr(
+                tree,
+                {id(tree.root): np.array([0.5, 0.5])},
+                {id(tree.root): "root"},
+                ["x", "y"],
+                {"A": "x", "B": "x", "C": "y"},
+                str(tmp_path / "plot.png"),
+            )
+
+        assert excinfo.value.code == 2
+        assert "matplotlib is required for discrete ASR plotting" in (
+            capsys.readouterr().out
+        )
+
+    @pytest.mark.parametrize("circular", [False, True])
+    def test_discrete_plot_supports_large_sparse_state_sets(
+        self, discrete_args, tmp_path, circular
+    ):
+        discrete_args.circular = circular
+        discrete_args.no_title = True
+        discrete_args.ylabel_fontsize = 0
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        states = [f"state_{index}" for index in range(11)]
+        posterior = np.zeros(len(states))
+        posterior[0] = 1.0
+        node_posteriors = {
+            id(clade): posterior
+            for clade in svc._iter_preorder(tree.root)
+            if clade.clades
+        }
+        output_path = tmp_path / f"large_states_{circular}.png"
+
+        svc._plot_discrete_asr(
+            tree,
+            node_posteriors,
+            {},
+            states,
+            {"A": states[0], "B": states[1], "C": states[2]},
+            str(output_path),
+        )
+
+        assert output_path.exists()
+
+    def test_discrete_plot_cache_rejects_unsafe_keys(
+        self, discrete_args, monkeypatch, tmp_path
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        clades = list(svc._iter_preorder(tree.root))
+        tips = [clade for clade in clades if not clade.clades]
+        node_posteriors = {id(tree.root): np.array([0.5, 0.5])}
+        common_args = (
+            tree,
+            clades,
+            tips,
+            node_posteriors,
+            {id(tree.root): "root"},
+            ["x", "y"],
+            {"A": "x", "B": "x", "C": "y"},
+            str(tmp_path / "plot.png"),
+        )
+        monkeypatch.setattr(
+            ancestral_module, "_DISCRETE_ASR_PLOT_CACHE_MAX_NODES", 0
+        )
+
+        assert svc._discrete_asr_plot_cache_key(*common_args) is None
+
+        monkeypatch.setattr(
+            ancestral_module, "_DISCRETE_ASR_PLOT_CACHE_MAX_NODES", 5000
+        )
+        monkeypatch.setattr(svc, "_collect_descendant_tip_names", lambda _tree: None)
+        assert svc._discrete_asr_plot_cache_key(*common_args) is None
+
+        discrete_args.color_file = str(tmp_path / "missing-colors.tsv")
+        svc = AncestralReconstruction(discrete_args)
+        assert svc._discrete_asr_plot_cache_key(*common_args) is None
+
+    def test_discrete_plot_cache_handles_storage_failures_and_eviction(
+        self, discrete_args, tmp_path
+    ):
+        svc = AncestralReconstruction(discrete_args)
+        missing_path = tmp_path / "missing.png"
+
+        svc._store_discrete_asr_plot_cache(None, str(missing_path))
+        svc._store_discrete_asr_plot_cache("missing", str(missing_path))
+        assert not ancestral_module._DISCRETE_ASR_PLOT_CACHE
+
+        for index in range(ancestral_module._DISCRETE_ASR_PLOT_CACHE_MAX + 1):
+            plot_path = tmp_path / f"plot-{index}.png"
+            plot_path.write_bytes(f"plot-{index}".encode("ascii"))
+            svc._store_discrete_asr_plot_cache(f"key-{index}", str(plot_path))
+
+        assert len(ancestral_module._DISCRETE_ASR_PLOT_CACHE) == (
+            ancestral_module._DISCRETE_ASR_PLOT_CACHE_MAX
+        )
+        assert "key-0" not in ancestral_module._DISCRETE_ASR_PLOT_CACHE
+        last_index = ancestral_module._DISCRETE_ASR_PLOT_CACHE_MAX
+        assert ancestral_module._DISCRETE_ASR_PLOT_CACHE[
+            f"key-{last_index}"
+        ] == f"plot-{last_index}".encode("ascii")
 
     def test_discrete_plot_skips_explicit_tight_layout(
         self, discrete_args, monkeypatch, tmp_path

--- a/tests/unit/services/tree/test_ancestral_reconstruction.py
+++ b/tests/unit/services/tree/test_ancestral_reconstruction.py
@@ -332,6 +332,53 @@ class TestTraitParsing:
                 str(trait_file), ["raccoon", "bear", "weasel"]
             )
 
+    def test_single_trait_rejects_non_numeric_values(self, default_args, tmp_path):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("raccoon\t1.04\nbear\theavy\nweasel\t-0.30\n")
+        svc = AncestralReconstruction(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_single_trait_data(
+                str(trait_file), ["raccoon", "bear", "weasel"]
+            )
+
+        assert excinfo.value.messages == [
+            "Non-numeric trait value 'heavy' for taxon 'bear' on line 2."
+        ]
+
+    def test_single_trait_reports_taxon_mismatches(
+        self, default_args, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1\nB\t2\nC\t3\nX\t4\n")
+        svc = AncestralReconstruction(default_args)
+
+        traits = svc._parse_single_trait_data(
+            str(trait_file), ["A", "B", "C", "D"]
+        )
+
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: D",
+            "Warning: 1 taxa in trait file but not in tree: X",
+        ]
+
+    def test_single_trait_requires_three_shared_taxa(
+        self, default_args, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1\nB\t2\nX\t3\n")
+        svc = AncestralReconstruction(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_single_trait_data(str(trait_file), ["A", "B", "C"])
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
+        assert "tree but not in trait file: C" in capsys.readouterr().err
+
     def test_multi_trait_format(self, default_args):
         svc = AncestralReconstruction(default_args)
         tree = svc.read_tree_file()
@@ -436,6 +483,88 @@ class TestTraitParsing:
 
         assert traits == {"raccoon": 1.04, "bear": 2.39, "weasel": -0.30}
         assert builtins.set is fail_set
+
+    @pytest.mark.parametrize(
+        ("contents", "expected_message"),
+        [
+            (
+                "# comment only\n\n",
+                "Multi-trait file must have a header row and at least one data row.",
+            ),
+            (
+                "taxon\nA\n",
+                "Header must have at least 2 columns (taxon + at least 1 trait).",
+            ),
+            (
+                "taxon\tbody_mass\n",
+                "Multi-trait file must have a header row and at least one data row.",
+            ),
+            (
+                "taxon\tbody_mass\nA\theavy\nB\t2\nC\t3\n",
+                "Non-numeric trait value 'heavy' for taxon 'A' "
+                "(trait 'body_mass') on line 2.",
+            ),
+        ],
+    )
+    def test_multi_trait_rejects_invalid_files(
+        self, default_args, tmp_path, contents, expected_message
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text(contents)
+        svc = AncestralReconstruction(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_multi_trait_data(
+                str(trait_file), ["A", "B", "C"], "body_mass"
+            )
+
+        assert expected_message in excinfo.value.messages
+
+    def test_multi_trait_reports_taxon_mismatches(
+        self, default_args, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text(
+            "taxon\tbody_mass\nA\t1\nB\t2\nC\t3\nX\t4\n"
+        )
+        svc = AncestralReconstruction(default_args)
+
+        traits = svc._parse_multi_trait_data(
+            str(trait_file), ["A", "B", "C", "D"], "body_mass"
+        )
+
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: D",
+            "Warning: 1 taxa in trait file but not in tree: X",
+        ]
+
+    def test_multi_trait_requires_three_shared_taxa(
+        self, default_args, tmp_path
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("taxon\tbody_mass\nA\t1\nB\t2\nX\t3\n")
+        svc = AncestralReconstruction(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_multi_trait_data(
+                str(trait_file), ["A", "B", "C"], "body_mass"
+            )
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
+
+    def test_multi_trait_file_not_found(self, default_args, tmp_path):
+        svc = AncestralReconstruction(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_multi_trait_data(
+                str(tmp_path / "missing.tsv"), ["A", "B", "C"], "body_mass"
+            )
+
+        assert "corresponds to no such file or directory" in excinfo.value.messages[0]
 
     def test_file_not_found(self, default_args):
         svc = AncestralReconstruction(default_args)
@@ -1017,6 +1146,24 @@ class TestNodeLabeling:
         assert labels[id(left)] == "left"
         assert labels[id(right)] == "N2"
 
+    def test_label_internal_nodes_supports_legacy_tree_interface(self, default_args):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(
+            StringIO("((A:1,B:1)left:1,(C:1,D:1):1)root;"),
+            "newick",
+        )
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        labels = svc._label_internal_nodes(LegacyTree())
+
+        left, right = tree.root.clades
+        assert labels[id(tree.root)] == "root"
+        assert labels[id(left)] == "left"
+        assert labels[id(right)] == "N1"
+
     def test_build_parent_map_uses_direct_preorder_traversal(
         self, default_args, monkeypatch
     ):
@@ -1065,6 +1212,21 @@ class TestNodeLabeling:
             parent_map[id(child)] is trifurcating for child in trifurcating.clades
         )
 
+    def test_build_parent_map_supports_legacy_tree_interface(self, default_args):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        parent_map = svc._build_parent_map(LegacyTree())
+
+        internal, terminal = tree.root.clades
+        assert parent_map[id(internal)] is tree.root
+        assert parent_map[id(terminal)] is tree.root
+        assert all(parent_map[id(child)] is internal for child in internal.clades)
+
     def test_get_descendant_tips_uses_direct_clade_traversal(
         self, default_args, monkeypatch
     ):
@@ -1077,6 +1239,33 @@ class TestNodeLabeling:
         monkeypatch.setattr(TreeMixin, "get_terminals", fail_get_terminals)
 
         assert svc._get_descendant_tips(tree, tree.root) == ["A", "B", "C", "D"]
+
+    def test_get_descendant_tips_falls_back_to_tree_mixin(
+        self, default_args, monkeypatch
+    ):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("((B:1,A:1):1,C:1);"), "newick")
+        monkeypatch.setattr(
+            ancestral_module.Tree,
+            "calculate_terminal_names_fast",
+            staticmethod(lambda _node: None),
+        )
+
+        assert svc._get_descendant_tips(tree, tree.root) == ["A", "B", "C"]
+
+    def test_descendant_collectors_reject_missing_root(self, default_args):
+        svc = AncestralReconstruction(default_args)
+
+        assert svc._collect_descendant_tip_counts(object()) is None
+        assert svc._collect_descendant_tip_names(object()) is None
+
+    def test_descendant_name_collection_rejects_unsortable_names(
+        self, default_args
+    ):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO("(:1,A:1);"), "newick")
+
+        assert svc._collect_descendant_tip_names(tree) is None
 
     def test_collect_descendant_tip_counts_uses_direct_traversal(
         self, default_args, monkeypatch
@@ -1131,6 +1320,24 @@ class TestNodeLabeling:
         names = svc._collect_descendant_tip_names(tree)
 
         assert list(names[id(tree.root)]) == ["A", "B", "C", "D"]
+
+    @pytest.mark.parametrize(
+        ("newick", "expected"),
+        [
+            ("((C:1,D:1):1,(A:1,B:1):1);", ["A", "B", "C", "D"]),
+            ("(A:1,B:1,C:1);", ["A", "B", "C"]),
+            ("(C:1,A:1,B:1);", ["A", "B", "C"]),
+        ],
+    )
+    def test_collect_descendant_tip_names_orders_child_ranges(
+        self, default_args, newick, expected
+    ):
+        svc = AncestralReconstruction(default_args)
+        tree = Phylo.read(StringIO(newick), "newick")
+
+        names = svc._collect_descendant_tip_names(tree)
+
+        assert list(names[id(tree.root)]) == expected
 
 
 class TestRun:

--- a/tests/unit/services/tree/test_ancestral_reconstruction.py
+++ b/tests/unit/services/tree/test_ancestral_reconstruction.py
@@ -684,6 +684,78 @@ class TestFastAnc:
         assert sigma2 > 0
         assert np.isfinite(ll)
 
+    def test_fast_anc_falls_back_when_direct_preorder_is_unavailable(
+        self, ci_args, monkeypatch
+    ):
+        svc = AncestralReconstruction(ci_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:2):0;"), "newick")
+        ordered_names = ["A", "B", "C"]
+        x = np.array([0.0, 1.0, 3.0])
+        node_labels = svc._label_internal_nodes(tree)
+        expected = svc._fast_anc(tree, x, ordered_names, node_labels)
+        original_iter_preorder = svc._iter_preorder
+        call_count = 0
+
+        def fail_first_preorder(root):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AttributeError("direct traversal unavailable")
+            return original_iter_preorder(root)
+
+        monkeypatch.setattr(svc, "_iter_preorder", fail_first_preorder)
+
+        observed = svc._fast_anc(tree, x, ordered_names, node_labels)
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2] == pytest.approx(expected[2])
+        assert observed[3] == pytest.approx(expected[3])
+
+    def test_fast_anc_handles_an_unobserved_subtree(self, ci_args):
+        svc = AncestralReconstruction(ci_args)
+        tree = Phylo.read(
+            StringIO("((X:1,Y:1):1,(A:1,B:1):1):0;"),
+            "newick",
+        )
+        observed_internal = tree.root.clades[1]
+        node_labels = svc._label_internal_nodes(tree)
+        del node_labels[id(tree.root)]
+
+        estimates, cis, sigma2, ll = svc._fast_anc(
+            tree,
+            np.array([1.0, 2.0]),
+            ["A", "B"],
+            node_labels,
+        )
+
+        observed_label = node_labels[id(observed_internal)]
+        assert estimates == {observed_label: pytest.approx(1.5)}
+        assert observed_label in cis
+        assert sigma2 == pytest.approx(0.5)
+        assert np.isfinite(ll)
+
+    def test_fast_anc_handles_zero_length_branches(self, ci_args):
+        svc = AncestralReconstruction(ci_args)
+        tree = Phylo.read(StringIO("((A:0,B:0):0,C:0):0;"), "newick")
+        node_labels = svc._label_internal_nodes(tree)
+
+        estimates, cis, sigma2, ll = svc._fast_anc(
+            tree,
+            np.array([1.0, 2.0, 3.0]),
+            ["A", "B", "C"],
+            node_labels,
+        )
+
+        assert all(np.isfinite(value) for value in estimates.values())
+        assert all(
+            np.isfinite(lower) and lower < estimates[label] < upper
+            for label, (lower, upper) in cis.items()
+        )
+        assert np.isfinite(sigma2)
+        assert sigma2 > 0
+        assert ll == float("-inf")
+
     def test_sigma2_from_contrasts_streams_polytomy_children(self, ci_args):
         svc = AncestralReconstruction(ci_args)
         tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
@@ -707,6 +779,44 @@ class TestFastAnc:
         combined_var = 0.5
         second = ((3.0 - combined_est) ** 2) / (1.0 + combined_var)
         assert sigma2 == pytest.approx((first + second) / 2.0)
+
+    def test_sigma2_from_contrasts_skips_unobserved_children(self, ci_args):
+        svc = AncestralReconstruction(ci_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        a, _, c = tree.root.clades
+        node_estimates = {id(a): 1.0, id(c): 3.0}
+        node_variances = {id(a): 0.0, id(c): 0.0}
+
+        sigma2 = svc._compute_sigma2_from_contrasts(
+            tree,
+            np.array([1.0, 3.0]),
+            node_estimates,
+            node_variances,
+            ["A", "C"],
+        )
+
+        assert sigma2 == pytest.approx(2.0)
+
+    def test_sigma2_from_contrasts_returns_zero_without_valid_contrasts(
+        self, ci_args
+    ):
+        svc = AncestralReconstruction(ci_args)
+        tree = Phylo.read(StringIO("(A:0,B:0,C:0);"), "newick")
+        node_estimates = {
+            id(tip): float(index)
+            for index, tip in enumerate(tree.root.clades, start=1)
+        }
+        node_variances = {id(tip): 0.0 for tip in tree.root.clades}
+
+        sigma2 = svc._compute_sigma2_from_contrasts(
+            tree,
+            np.array([1.0, 2.0, 3.0]),
+            node_estimates,
+            node_variances,
+            ["A", "B", "C"],
+        )
+
+        assert sigma2 == 0.0
 
 
 class TestAncML:
@@ -764,6 +874,24 @@ class TestAncML:
         )
         assert ll < 0  # Log-likelihood should be negative for real data
 
+    def test_singular_vcv_matrix_is_reported_to_the_user(self, ml_args, mocker):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        mocker.patch.object(svc, "_build_vcv_matrix", return_value=np.zeros((3, 3)))
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._anc_ml(
+                tree,
+                np.array([1.0, 2.0, 3.0]),
+                ["A", "B", "C"],
+                svc._label_internal_nodes(tree),
+            )
+
+        assert excinfo.value.messages == [
+            "Singular VCV matrix: cannot invert.",
+            "Check that the tree has valid branch lengths.",
+        ]
+
     def test_cross_covariance_fast_path_does_not_call_distance_get_path_or_mrca(
         self, ml_args, monkeypatch
     ):
@@ -795,6 +923,87 @@ class TestAncML:
         assert observed[1] == pytest.approx(expected[1])
         assert observed[2] == pytest.approx(expected[2])
         assert observed[3] == pytest.approx(expected[3])
+
+    def test_ml_falls_back_to_root_paths_when_direct_covariances_fail(
+        self, ml_args, mocker
+    ):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:3):0;"), "newick")
+        ordered_names = ["A", "B", "C"]
+        x = np.array([0.0, 1.0, 3.0])
+        node_labels = svc._label_internal_nodes(tree)
+        expected = svc._anc_ml(tree, x, ordered_names, node_labels)
+        mocker.patch.object(
+            svc, "_prepare_ml_cross_covariances_direct", return_value=None
+        )
+
+        observed = svc._anc_ml(tree, x, ordered_names, node_labels)
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2] == pytest.approx(expected[2])
+        assert observed[3] == pytest.approx(expected[3])
+
+    def test_ml_falls_back_to_distance_covariances_without_depths(
+        self, ml_args, mocker
+    ):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:3):0;"), "newick")
+        ordered_names = ["A", "B", "C"]
+        x = np.array([0.0, 1.0, 3.0])
+        node_labels = svc._label_internal_nodes(tree)
+        expected = svc._anc_ml(tree, x, ordered_names, node_labels)
+        mocker.patch.object(tree, "depths", side_effect=TypeError("no depths"))
+
+        observed = svc._anc_ml(tree, x, ordered_names, node_labels)
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2] == pytest.approx(expected[2])
+        assert observed[3] == pytest.approx(expected[3])
+
+    def test_ml_returns_no_node_estimates_without_node_labels(self, ml_args):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:3):0;"), "newick")
+
+        estimates, cis, sigma2, ll = svc._anc_ml(
+            tree,
+            np.array([0.0, 1.0, 3.0]),
+            ["A", "B", "C"],
+            {},
+        )
+
+        assert estimates == {}
+        assert cis == {}
+        assert sigma2 > 0
+        assert np.isfinite(ll)
+
+    def test_ml_clamps_negative_conditional_variance(self, ml_args, mocker):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:3):0;"), "newick")
+        internal = tree.root.clades[0]
+        node_labels = {id(internal): "internal"}
+        mocker.patch.object(
+            svc,
+            "_prepare_ml_cross_covariances_direct",
+            return_value=(
+                [internal],
+                ["internal"],
+                np.array([0.0]),
+                np.array([[10.0, 0.0, 0.0]]),
+            ),
+        )
+
+        estimates, cis, _, _ = svc._anc_ml(
+            tree,
+            np.array([0.0, 1.0, 3.0]),
+            ["A", "B", "C"],
+            node_labels,
+        )
+
+        assert cis["internal"] == pytest.approx(
+            (estimates["internal"], estimates["internal"])
+        )
 
     def test_ml_cross_covariance_uses_direct_tree_traversal(
         self, ml_args, monkeypatch
@@ -911,6 +1120,130 @@ class TestAncML:
         )
 
         assert np.isfinite(observed)
+
+    @pytest.mark.parametrize(
+        ("ordered_names", "sigma2"),
+        [(["A"], 0.0), ([], 1.0)],
+    )
+    def test_compute_log_likelihood_rejects_empty_or_nonpositive_inputs(
+        self, ml_args, mocker, ordered_names, sigma2
+    ):
+        svc = AncestralReconstruction(ml_args)
+        build_vcv = mocker.patch.object(svc, "_build_vcv_matrix")
+
+        observed = svc._compute_log_likelihood(
+            object(), np.zeros(len(ordered_names)), ordered_names, sigma2
+        )
+
+        assert observed == float("-inf")
+        build_vcv.assert_not_called()
+
+    def test_compute_log_likelihood_falls_back_to_matrix_inverse(
+        self, ml_args, mocker
+    ):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("((A:1,B:2):1,C:3):0;"), "newick")
+        ordered_names = ["A", "B", "C"]
+        x = np.array([0.0, 1.0, 3.0])
+        expected = svc._compute_log_likelihood(tree, x, ordered_names, 0.75)
+        mocker.patch.object(
+            ancestral_module, "cho_factor", side_effect=ValueError("not positive")
+        )
+
+        observed = svc._compute_log_likelihood(tree, x, ordered_names, 0.75)
+
+        assert observed == pytest.approx(expected)
+
+    def test_compute_log_likelihood_rejects_indefinite_covariance(
+        self, ml_args, mocker
+    ):
+        svc = AncestralReconstruction(ml_args)
+        mocker.patch.object(
+            svc,
+            "_build_vcv_matrix",
+            return_value=np.diag([1.0, -1.0]),
+        )
+        mocker.patch.object(
+            ancestral_module, "cho_factor", side_effect=ValueError("not positive")
+        )
+
+        observed = svc._compute_log_likelihood(
+            object(), np.array([0.0, 1.0]), ["A", "B"], 1.0
+        )
+
+        assert observed == float("-inf")
+
+    def test_compute_log_likelihood_handles_inverse_failure(
+        self, ml_args, mocker
+    ):
+        svc = AncestralReconstruction(ml_args)
+        mocker.patch.object(svc, "_build_vcv_matrix", return_value=np.eye(2))
+        mocker.patch.object(
+            ancestral_module, "cho_factor", side_effect=ValueError("not positive")
+        )
+        mocker.patch.object(
+            ancestral_module.np.linalg,
+            "inv",
+            side_effect=np.linalg.LinAlgError("singular"),
+        )
+
+        observed = svc._compute_log_likelihood(
+            object(), np.array([0.0, 1.0]), ["A", "B"], 1.0
+        )
+
+        assert observed == float("-inf")
+
+    @pytest.mark.parametrize(
+        ("tree_newick", "ordered_names"),
+        [
+            ("(A:1,B:1);", ["A", "A"]),
+            ("(A:1,A:1,B:1);", ["A", "B"]),
+            ("(A:1,B:1);", ["A", "B", "C"]),
+        ],
+    )
+    def test_direct_ml_covariances_reject_ambiguous_tip_mappings(
+        self, ml_args, tree_newick, ordered_names
+    ):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO(tree_newick), "newick")
+
+        result = svc._prepare_ml_cross_covariances_direct(
+            tree,
+            ordered_names,
+            svc._label_internal_nodes(tree),
+            tree.depths(),
+            tree.depths()[tree.root],
+        )
+
+        assert result is None
+
+    def test_direct_ml_covariances_ignore_unrequested_tips(self, ml_args):
+        svc = AncestralReconstruction(ml_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,X:1);"), "newick")
+
+        clades, labels, distances, covariances = (
+            svc._prepare_ml_cross_covariances_direct(
+                tree,
+                ["A", "B"],
+                svc._label_internal_nodes(tree),
+                tree.depths(),
+                tree.depths()[tree.root],
+            )
+        )
+
+        assert clades == [tree.root]
+        assert labels == ["N1"]
+        np.testing.assert_array_equal(distances, [0.0])
+        np.testing.assert_array_equal(covariances, [[0.0, 0.0]])
+
+    def test_direct_ml_covariances_require_a_root(self, ml_args):
+        svc = AncestralReconstruction(ml_args)
+
+        result = svc._prepare_ml_cross_covariances_direct(
+            object(), ["A"], {}, {}, 0.0
+        )
+
+        assert result is None
 
     def test_ml_reuses_inverse_weighted_residuals(self, ml_args, monkeypatch):
         args = Namespace(**vars(ml_args))

--- a/tests/unit/services/tree/test_base_tree_service.py
+++ b/tests/unit/services/tree/test_base_tree_service.py
@@ -1,6 +1,4 @@
-from argparse import Namespace
 from io import StringIO
-from pathlib import Path
 import pickle as stdlib_pickle
 import subprocess
 import sys
@@ -695,6 +693,89 @@ class TestTreeBase:
         assert expected_message in exc.value.messages[0].lower()
 
     @pytest.mark.parametrize(
+        ("newick", "expected_message"),
+        [
+            pytest.param("(a]:1,b:1);", "comment delimiter", id="unmatched-close-comment"),
+            pytest.param(")a,b(;", "parentheses", id="leading-close-parenthesis"),
+            pytest.param("('a,b);", "quote", id="unmatched-quote"),
+            pytest.param("(a[comment,b);", "comment delimiter", id="unmatched-comment"),
+            pytest.param("(a:not-a-number,b:1);", "valid number", id="invalid-length"),
+            pytest.param("(a,b)", "semicolon", id="missing-semicolon"),
+        ],
+    )
+    def test_newick_document_validator_reports_delimiter_and_length_errors(
+        self,
+        tmp_path,
+        newick,
+        expected_message,
+    ):
+        tree_path = tmp_path / "invalid-document.tre"
+        tree_path.write_text(newick)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            Tree._read_single_newick_document(str(tree_path))
+
+        assert expected_message in exc_info.value.messages[0]
+
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            pytest.param("('a''b':1,c:2);", id="escaped-quote"),
+            pytest.param("(a[outer[inner]]:1,b:2);", id="nested-comment"),
+            pytest.param("(a:   1,b:2);", id="length-leading-whitespace"),
+        ],
+    )
+    def test_newick_document_validator_accepts_supported_lexical_forms(
+        self, tmp_path, newick
+    ):
+        tree_path = tmp_path / "valid-document.tre"
+        tree_path.write_text(newick)
+
+        assert Tree._read_single_newick_document(str(tree_path)) == newick
+
+    def test_cached_tree_read_normalizes_parser_errors(self, tmp_path, mocker):
+        tree_path = tmp_path / "parser-error.tre"
+        tree_path.write_text("(a,b);")
+        Tree._cached_tree_read.cache_clear()
+        mocker.patch("Bio.Phylo.read", side_effect=ValueError("parser rejected tree"))
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            Tree._cached_tree_read(str(tree_path), "newick", "hash")
+
+        assert exc_info.value.messages == [
+            f"Invalid Newick tree {tree_path}: parser rejected tree"
+        ]
+
+    def test_cached_non_newick_read_skips_newick_validation(self, mocker):
+        parsed = object()
+        mocked_read = mocker.patch("Bio.Phylo.read", return_value=parsed)
+        validate_document = mocker.patch.object(Tree, "_read_single_newick_document")
+        validate_tree = mocker.patch.object(Tree, "_validate_parsed_newick")
+        Tree._cached_tree_read.cache_clear()
+
+        observed = Tree._cached_tree_read("tree.nex", "nexus", "hash")
+
+        assert observed is parsed
+        mocked_read.assert_called_once_with("tree.nex", "nexus")
+        validate_document.assert_not_called()
+        validate_tree.assert_not_called()
+
+    def test_parsed_newick_validation_rejects_nonfinite_branch_length(self):
+        tree = NewickTree(
+            root=Clade(
+                clades=[
+                    Clade(name="a", branch_length=float("nan")),
+                    Clade(name="b", branch_length=1.0),
+                ]
+            )
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            Tree._validate_parsed_newick(tree, "tree.tre")
+
+        assert "branch lengths must be finite" in exc_info.value.messages[0]
+
+    @pytest.mark.parametrize(
         "newick",
         [
             pytest.param("('a b':1,b:2);", id="quoted-tip"),
@@ -714,6 +795,67 @@ class TestTreeBase:
             tip.name for tip in expected.get_terminals()
         ]
         assert observed.total_branch_length() == expected.total_branch_length()
+
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            pytest.param("A(B,C);", id="opening-after-label"),
+            pytest.param("(,A);", id="leading-comma"),
+            pytest.param("();", id="empty-clade"),
+            pytest.param("(A,A);", id="duplicate-tip"),
+            pytest.param("(:1,A);", id="length-without-label"),
+            pytest.param("(A:,B);", id="empty-length"),
+            pytest.param("(A:not-a-number,B);", id="invalid-length"),
+            pytest.param("(A:nan,B);", id="nonfinite-length"),
+            pytest.param("(A:1 extra,B);", id="token-after-length"),
+            pytest.param("((A,B)inner extra,C);", id="second-internal-label"),
+        ],
+    )
+    def test_simple_newick_scanners_decline_unsupported_syntax(
+        self, tmp_path, newick
+    ):
+        tree_path = tmp_path / "unsupported-simple.tre"
+        tree_path.write_text(newick)
+
+        assert Tree._scan_simple_newick_summary(str(tree_path)) is None
+        assert Tree._scan_simple_newick_tip_names(str(tree_path)) is None
+
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            pytest.param("(A:,B:1);", id="empty-terminal-length"),
+            pytest.param("(A:not-a-number,B:1);", id="invalid-terminal-length"),
+            pytest.param("(A:nan,B:1);", id="nonfinite-terminal-length"),
+            pytest.param("(A B,C);", id="invalid-child-separator"),
+            pytest.param("((A,B):,C);", id="empty-internal-length"),
+            pytest.param("(:1,A);", id="terminal-without-label"),
+            pytest.param("(A,);", id="missing-child"),
+            pytest.param("(A);", id="fewer-than-two-tips"),
+        ],
+    )
+    def test_terminal_distance_scanner_declines_unsupported_syntax(
+        self, tmp_path, newick
+    ):
+        tree_path = tmp_path / "unsupported-distances.tre"
+        tree_path.write_text(newick)
+
+        assert Tree._scan_simple_newick_terminal_distance_stats(str(tree_path)) is None
+
+    def test_terminal_distance_scanner_excludes_root_branch_length(self, tmp_path):
+        tree_path = tmp_path / "root-length.tre"
+        tree_path.write_text("((A:1,B:2):3,C:4):5;")
+
+        assert Tree._scan_simple_newick_terminal_distance_stats(str(tree_path)) == (
+            3,
+            13.0,
+            57.0,
+        )
+
+    def test_terminal_distance_scanner_falls_back_for_deep_tree(self, tmp_path):
+        tree_path = tmp_path / "deep-tree.tre"
+        tree_path.write_text("(" * 2_000 + "A" + ")" * 2_000 + ";")
+
+        assert Tree._scan_simple_newick_terminal_distance_stats(str(tree_path)) is None
 
     def test_get_simple_newick_summary_uses_cached_file_hash(self, tmp_path):
         tree_path = tmp_path / "tree.tre"

--- a/tests/unit/services/tree/test_bipartition_support_stats.py
+++ b/tests/unit/services/tree/test_bipartition_support_stats.py
@@ -282,6 +282,60 @@ assert "Bio.Phylo" not in sys.modules
             is None
         )
 
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            ":1;",
+            "A:;",
+            "A:not-a-number;",
+            "(",
+            "(A:1",
+            "(A:1 X",
+            "(A:1)90:;",
+            "(A:1)not-support:1;",
+            "A:1",
+            "A:1; trailing",
+        ],
+        ids=[
+            "empty-label",
+            "empty-length",
+            "invalid-length",
+            "missing-child",
+            "unterminated-group",
+            "invalid-separator",
+            "invalid-internal-length",
+            "invalid-support",
+            "missing-semicolon",
+            "trailing-content",
+        ],
+    )
+    def test_scan_simple_newick_bipartitions_rejects_malformed_syntax(
+        self, tmp_path, newick
+    ):
+        tree = tmp_path / "malformed.tre"
+        tree.write_text(newick)
+
+        result = BipartitionSupportStats._scan_simple_newick_bipartitions(
+            str(tree)
+        )
+
+        assert result is None
+
+    def test_scan_simple_newick_bipartitions_handles_recursion_limit(
+        self, tmp_path
+    ):
+        depth = sys.getrecursionlimit() + 10
+        tree = tmp_path / "deep-tree.tre"
+        tree.write_text(
+            "(" * depth + "A:1" + ")" * depth + ";"
+        )
+
+        result = BipartitionSupportStats._scan_simple_newick_bipartitions(
+            str(tree)
+        )
+
+        assert result is None
+
     def test_to_builtin_converts_numpy_scalars(self, args):
         t = BipartitionSupportStats(args)
         value = {"a": np.int64(1), "b": [np.float64(1.5)]}
@@ -344,6 +398,61 @@ assert "Bio.Phylo" not in sys.modules
 
         assert vals == [90, 80]
         assert names == [["A", "B"], ["C", "D"]]
+
+    def test_get_bipartition_support_vals_supports_generic_tree(self, args):
+        t = BipartitionSupportStats(args)
+        tree = Phylo.read(StringIO("((A:1,B:1)90:1,C:2)80;"), "newick")
+
+        class GenericTree:
+            def find_clades(self, order):
+                return tree.find_clades(order=order)
+
+            def get_nonterminals(self):
+                return tree.get_nonterminals()
+
+        generic_tree = GenericTree()
+        vals, names = t.get_bipartition_support_vals(generic_tree)
+
+        assert vals == [80, 90]
+        assert names == [["A", "B", "C"], ["A", "B"]]
+        assert t.get_bipartition_support_values(generic_tree) == vals
+
+    def test_direct_bipartition_traversals_reject_incompatible_trees(self):
+        class MalformedRoot:
+            clades = [object()]
+            confidence = None
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        assert BipartitionSupportStats._get_bipartition_support_vals_direct(
+            object()
+        ) is None
+        assert BipartitionSupportStats._get_bipartition_support_values_array_direct(
+            object()
+        ) is None
+        assert BipartitionSupportStats._get_bipartition_support_vals_direct(
+            MalformedTree()
+        ) is None
+        assert BipartitionSupportStats._get_bipartition_support_values_array_direct(
+            MalformedTree()
+        ) is None
+
+    def test_direct_bipartition_traversals_support_multifurcations(self):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1)90;"), "newick")
+
+        vals, names = (
+            BipartitionSupportStats._get_bipartition_support_vals_direct(tree)
+        )
+        values = (
+            BipartitionSupportStats._get_bipartition_support_values_array_direct(
+                tree
+            )
+        )
+
+        assert vals == [90]
+        assert names == [["A", "B", "C"]]
+        assert values.tolist() == [90.0]
 
     def test_bipartition_support_vals_direct_preserves_order_without_child_reversed(
         self,

--- a/tests/unit/services/tree/test_chronogram.py
+++ b/tests/unit/services/tree/test_chronogram.py
@@ -82,6 +82,29 @@ def _make_args(**overrides):
 
 
 class TestChronogram:
+    @pytest.mark.parametrize("circular", [False, True])
+    def test_color_annotations_render_in_both_layouts(self, tmp_path, circular):
+        pytest.importorskip("matplotlib")
+        color_file = tmp_path / "colors.tsv"
+        color_file.write_text(
+            "bear,raccoon\trange\t#ffcc00\tRange\n"
+            "bear,raccoon\tclade\t#cc0033\tClade\n"
+            "bear\tlabel\t#0033cc\n"
+        )
+        output = tmp_path / f"chronogram-{circular}.png"
+        svc = Chronogram(
+            _make_args(
+                plot_output=str(output),
+                circular=circular,
+                color_file=str(color_file),
+            )
+        )
+
+        svc.run()
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
     def test_run_reuses_unmodified_tree(self, mocker, tmp_path):
         out = str(tmp_path / "chrono.png")
         svc = Chronogram(_make_args(plot_output=out))

--- a/tests/unit/services/tree/test_chronogram.py
+++ b/tests/unit/services/tree/test_chronogram.py
@@ -51,6 +51,22 @@ def test_lazy_numpy_caches_resolved_attributes():
     assert lazy_np._module is not None
 
 
+def test_color_annotation_wrappers_delegate(mocker):
+    draw_rect = mocker.patch(
+        "phykit.helpers.color_annotations.draw_range_rect",
+        return_value="rect",
+    )
+    draw_wedge = mocker.patch(
+        "phykit.helpers.color_annotations.draw_range_wedge",
+        return_value="wedge",
+    )
+
+    assert module.draw_range_rect("axis", color="red") == "rect"
+    assert module.draw_range_wedge("axis", color="blue") == "wedge"
+    draw_rect.assert_called_once_with("axis", color="red")
+    draw_wedge.assert_called_once_with("axis", color="blue")
+
+
 def _make_args(**overrides):
     defaults = dict(
         tree=TREE, root_age=70.0, plot_output=None, timescale="auto",
@@ -149,6 +165,63 @@ class TestChronogram:
         intervals = Chronogram._parse_hpd_intervals(tree, 70.0, 1.0)
 
         assert intervals == {}
+
+    def test_parse_hpd_intervals_supports_generic_tree_and_ci_pattern(self):
+        internal = Clade(clades=[Clade(name="A"), Clade(name="B")])
+        internal.comment = "[&CI={8.5,3.25}]"
+
+        class GenericTree:
+            root = object()
+
+            def find_clades(self, order=None):
+                assert order == "preorder"
+                return [internal]
+
+        intervals = Chronogram._parse_hpd_intervals(
+            GenericTree(), 70.0, 1.0
+        )
+
+        assert intervals[id(internal)] == (3.25, 8.5)
+
+    @pytest.mark.parametrize(
+        "helper",
+        [
+            Chronogram._preorder_clades_direct,
+            Chronogram._postorder_clades_direct,
+        ],
+    )
+    def test_direct_traversals_reject_generic_and_malformed_trees(self, helper):
+        assert helper(Namespace(root=object())) is None
+        assert helper(Namespace(root=Namespace(clades=[object()]))) is None
+
+    @pytest.mark.parametrize(
+        ("root_age", "expected"),
+        [
+            (10, 2),
+            (50, 10),
+            (150, 20),
+            (300, 50),
+            (301, 100),
+        ],
+    )
+    def test_nice_tick_interval_boundaries(self, root_age, expected):
+        assert Chronogram._nice_tick_interval(root_age) == expected
+
+    def test_descendant_cache_supports_generic_tree_protocol(self):
+        tip_a = Clade(name="A")
+        tip_b = Clade(name="B")
+        internal = Clade(clades=[tip_a, tip_b])
+
+        class GenericTree:
+            root = object()
+
+            def find_clades(self, order=None):
+                assert order == "postorder"
+                return [tip_a, tip_b, internal]
+
+        cache = Chronogram._build_descendant_tip_name_cache(GenericTree())
+
+        assert cache[id(internal)] == ("A", "B")
 
     @pytest.mark.parametrize("circular", [False, True])
     def test_plot_uses_direct_tree_traversal(self, monkeypatch, tmp_path, circular):

--- a/tests/unit/services/tree/test_concordance_asr.py
+++ b/tests/unit/services/tree/test_concordance_asr.py
@@ -824,6 +824,43 @@ class TestCachedDescendantAssembly:
         assert node_data[0][1] == [1.0, 2.0]
         assert node_data[0][2] == 0.1
 
+    def test_uncertainty_node_data_uses_distribution_estimates_and_skips_short_rows(
+        self, default_args
+    ):
+        svc = ConcordanceAsr(default_args)
+        species_tree = svc.read_tree_file()
+        internal_clades = [
+            clade
+            for clade in species_tree.find_clades(order="preorder")
+            if not clade.is_terminal()
+        ]
+        clade_tip_sets = svc._collect_clade_tip_sets(species_tree)
+        result = {
+            "method": "distribution",
+            "ancestral_estimates": {
+                "included": {
+                    "descendants": sorted(clade_tip_sets[id(internal_clades[0])]),
+                    "gene_tree_estimates": [1.0, 2.0],
+                    "gcf": 0.8,
+                    "estimate": 1.5,
+                },
+                "short": {
+                    "descendants": sorted(clade_tip_sets[id(internal_clades[1])]),
+                    "gene_tree_estimates": [1.0],
+                    "gcf": 0.5,
+                    "estimate": 1.0,
+                },
+                "missing-descendants": {
+                    "gene_tree_estimates": [3.0, 4.0],
+                },
+            },
+        }
+
+        node_data = svc._collect_uncertainty_node_data(species_tree, result)
+
+        assert len(node_data) == 1
+        assert node_data[0][1] == [1.0, 2.0]
+
 
 class TestNNIAlternatives:
     def test_root_and_unpaired_nodes_have_no_nni_alternatives(self, default_args):
@@ -1099,6 +1136,89 @@ class TestWeightedMethod:
             assert "var_parameter" in entry
             assert 0.0 <= entry["gcf"] <= 1.0
 
+    def test_weighted_assembly_skips_unlabeled_and_unestimated_nodes(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        species_tree = svc.read_tree_file()
+        svc._asr = Namespace(
+            _label_internal_nodes=lambda _tree: {id(species_tree.root): "root"},
+            _build_parent_map=lambda _tree: {},
+        )
+        clade_tip_sets = svc._collect_clade_tip_sets(species_tree)
+        monkeypatch.setattr(svc, "_run_asr_on_tree", lambda *_args: ({}, {}, 1.0))
+        monkeypatch.setattr(svc, "_compute_gcf_per_node", lambda *_args: {})
+        monkeypatch.setattr(
+            svc,
+            "_collect_clade_tip_sets",
+            lambda _tree: clade_tip_sets,
+        )
+
+        result = svc._run_weighted(
+            species_tree,
+            [],
+            {name: 1.0 for name in svc.get_tip_names_from_tree(species_tree)},
+            set(svc.get_tip_names_from_tree(species_tree)),
+        )
+
+        assert result["ancestral_estimates"] == {}
+
+    def test_weighted_assembly_handles_missing_and_extra_nni_estimates(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        species_tree = svc.read_tree_file()
+        target = next(
+            clade
+            for clade in species_tree.find_clades(order="preorder")
+            if clade is not species_tree.root and not clade.is_terminal()
+        )
+        clade_tip_sets = svc._collect_clade_tip_sets(species_tree)
+        target_desc = clade_tip_sets[id(target)]
+        expected_desc = [frozenset({f"alt-{index}"}) for index in range(3)]
+        alt_trees = [object(), object(), object()]
+        svc._asr = Namespace(
+            _label_internal_nodes=lambda _tree: {id(target): "target"},
+            _build_parent_map=lambda _tree: {},
+        )
+
+        def run_asr(tree, _trait_values):
+            if tree is species_tree:
+                return {target_desc: 1.0}, {}, 1.0
+            index = alt_trees.index(tree)
+            if index == 1:
+                return {expected_desc[index]: 2.0}, {}, 1.0
+            return {}, {}, 1.0
+
+        monkeypatch.setattr(svc, "_run_asr_on_tree", run_asr)
+        monkeypatch.setattr(
+            svc,
+            "_compute_gcf_per_node",
+            lambda *_args: {id(target): (0.0, 0.0, 0.0)},
+        )
+        monkeypatch.setattr(
+            svc,
+            "_collect_clade_tip_sets",
+            lambda _tree: clade_tip_sets,
+        )
+        monkeypatch.setattr(
+            svc,
+            "_build_nni_alternative_at_node",
+            lambda *_args: list(zip(alt_trees, expected_desc)),
+        )
+
+        result = svc._run_weighted(
+            species_tree,
+            [object()],
+            {name: 1.0 for name in svc.get_tip_names_from_tree(species_tree)},
+            set(svc.get_tip_names_from_tree(species_tree)),
+        )
+
+        entry = result["ancestral_estimates"]["target"]
+        assert entry["estimate"] == 0.0
+        assert entry["source_estimates"] == [1.0, 2.0]
+        assert entry["source_weights"] == [0.0, 0.0]
+
     def test_all_concordant_matches_standard_asr(self, default_args):
         """When all gene trees match species tree, result should be close to standard ASR."""
         svc = ConcordanceAsr(default_args)
@@ -1173,6 +1293,33 @@ class TestDistributionMethod:
             "ci_lower" in e for e in result["ancestral_estimates"].values()
         )
         assert has_ci, "Distribution method should produce CIs"
+
+    def test_distribution_skips_unlabeled_nodes_without_estimates(
+        self, distribution_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(distribution_args)
+        species_tree = svc.read_tree_file()
+        svc._asr = Namespace(
+            _label_internal_nodes=lambda _tree: {id(species_tree.root): "root"}
+        )
+        clade_tip_sets = svc._collect_clade_tip_sets(species_tree)
+        monkeypatch.setattr(svc, "_compute_gcf_per_node", lambda *_args: {})
+        monkeypatch.setattr(svc, "_run_asr_on_tree", lambda *_args: ({}, {}, 0.0))
+        monkeypatch.setattr(
+            svc,
+            "_collect_clade_tip_sets",
+            lambda _tree: clade_tip_sets,
+        )
+
+        result = svc._run_distribution(
+            species_tree,
+            [object(), object()],
+            {name: 1.0 for name in svc.get_tip_names_from_tree(species_tree)},
+            set(svc.get_tip_names_from_tree(species_tree)),
+        )
+
+        assert result["ancestral_estimates"] == {}
+        assert result["sigma2"] == 0.0
 
 
 class TestRun:
@@ -1272,6 +1419,53 @@ class TestRun:
         prune.assert_called_once_with(species_copy, ["dog"])
         assert run_weighted.call_args.args[0] is pruned_species
 
+    def test_run_supports_multi_trait_ladderized_uncertainty_output(
+        self, default_args, tmp_path, mocker
+    ):
+        default_args.trait = "body_mass"
+        default_args.ladderize = True
+        default_args.plot_uncertainty = str(tmp_path / "uncertainty.png")
+        svc = ConcordanceAsr(default_args)
+        species_tree = svc.read_tree_file()
+        gene_trees = svc._parse_gene_trees(GENE_TREES)
+        all_taxa = set(svc.get_tip_names_from_tree(species_tree))
+        trait_values = {
+            taxon: float(index)
+            for index, taxon in enumerate(svc.get_tip_names_from_tree(species_tree))
+        }
+        mocker.patch.object(
+            svc,
+            "read_tree_file_unmodified",
+            return_value=species_tree,
+        )
+        mocker.patch.object(svc, "_parse_gene_trees", return_value=gene_trees)
+        mocker.patch.object(
+            svc,
+            "_normalize_taxa",
+            return_value=(gene_trees, all_taxa),
+        )
+        mocker.patch(
+            "phykit.services.tree.ancestral_reconstruction."
+            "AncestralReconstruction._parse_multi_trait_data",
+            return_value=trait_values,
+        )
+        mocker.patch.object(svc, "_fast_tree_copy", return_value=species_tree)
+        ladderize = mocker.spy(species_tree, "ladderize")
+        result = {"method": "weighted", "ancestral_estimates": {}}
+        mocker.patch.object(svc, "_run_weighted", return_value=result)
+        plot_uncertainty = mocker.patch.object(svc, "_plot_uncertainty")
+        mocker.patch.object(svc, "_print_text_output")
+
+        svc.run()
+
+        ladderize.assert_called_once_with()
+        plot_uncertainty.assert_called_once_with(
+            species_tree,
+            result,
+            default_args.plot_uncertainty,
+        )
+        assert result["plot_uncertainty"] == default_args.plot_uncertainty
+
     def test_text_output(self, default_args):
         svc = ConcordanceAsr(default_args)
         with patch("builtins.print") as mock_print:
@@ -1347,6 +1541,66 @@ class TestRun:
 
 
 class TestCircularPlot:
+    def test_uncertainty_plot_skips_empty_and_unmatched_results(
+        self, default_args, tmp_path, capsys
+    ):
+        pytest.importorskip("matplotlib")
+        svc = ConcordanceAsr(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+
+        svc._plot_uncertainty(
+            tree,
+            {"method": "weighted", "ancestral_estimates": {}},
+            str(tmp_path / "empty.png"),
+        )
+        svc._plot_uncertainty(
+            tree,
+            {
+                "method": "weighted",
+                "ancestral_estimates": {
+                    "missing": {
+                        "descendants": ["X", "Y"],
+                        "source_estimates": [1.0, 2.0],
+                    }
+                },
+            },
+            str(tmp_path / "unmatched.png"),
+        )
+
+        assert "No nodes with enough estimates" in capsys.readouterr().out
+        assert not (tmp_path / "empty.png").exists()
+        assert not (tmp_path / "unmatched.png").exists()
+
+    def test_uncertainty_plot_covers_concordance_colors_and_title(
+        self, default_args, tmp_path
+    ):
+        pytest.importorskip("matplotlib")
+        default_args.fig_height = 6
+        default_args.title = "Concordance uncertainty"
+        svc = ConcordanceAsr(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        clade_tip_sets = svc._collect_clade_tip_sets(tree)
+        gcfs = iter([0.8, 0.5, 0.2])
+        estimates = {}
+        for index, clade in enumerate(svc._iter_preorder(tree.root)):
+            if not clade.clades:
+                continue
+            estimates[f"N{index}"] = {
+                "descendants": sorted(clade_tip_sets[id(clade)]),
+                "source_estimates": [float(index), float(index + 1)],
+                "gcf": next(gcfs),
+                "estimate": float(index),
+            }
+
+        output_path = tmp_path / "uncertainty-colors.png"
+        svc._plot_uncertainty(
+            tree,
+            {"method": "weighted", "ancestral_estimates": estimates},
+            str(output_path),
+        )
+
+        assert output_path.exists()
+
     @pytest.mark.parametrize("circular", [False, True])
     def test_concordance_plot_uses_direct_tree_traversal(
         self, default_args, monkeypatch, tmp_path, circular

--- a/tests/unit/services/tree/test_concordance_asr.py
+++ b/tests/unit/services/tree/test_concordance_asr.py
@@ -1,7 +1,5 @@
 import copy
 import builtins
-import json
-import math
 import pickle as stdlib_pickle
 import subprocess
 import sys
@@ -112,6 +110,25 @@ def test_lazy_pickle_caches_resolved_copy_helpers(monkeypatch):
         ("dumps", ("tree2",), {"protocol": protocol}),
         ("loads", ("tree2",), {}),
     ]
+
+
+def test_lazy_pickle_loads_first_caches_dumps_helper(monkeypatch):
+    lazy_pickle = concordance_asr_module._LazyPickle()
+    monkeypatch.setattr(stdlib_pickle, "loads", lambda value: value)
+
+    assert lazy_pickle.loads("tree") == "tree"
+    assert lazy_pickle.__dict__["dumps"] is stdlib_pickle.dumps
+
+
+def test_lazy_json_output_delegates_to_helper(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "phykit.helpers.json_output.print_json",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or "printed",
+    )
+
+    assert concordance_asr_module.print_json({"result": 1}, indent=2) == "printed"
+    assert calls == [(({"result": 1},), {"indent": 2})]
 
 
 here = Path(__file__).resolve().parent
@@ -359,6 +376,43 @@ class TestTaxaNormalization:
         assert len(shared) == 8
         assert spy.call_count == (2 * len(gene_trees)) + 1
 
+    def test_shared_mode_prunes_species_and_gene_tree_taxa(self, default_args):
+        svc = ConcordanceAsr(default_args)
+        species_tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        gene_trees = [
+            Phylo.read(StringIO("((A:1,B:1):1,(C:1,E:1):1);"), "newick"),
+            Phylo.read(StringIO("((A:1,C:1):1,(B:1,F:1):1);"), "newick"),
+        ]
+
+        pruned_trees, shared = svc._normalize_taxa(
+            species_tree,
+            gene_trees,
+            {"A", "B", "C", "D"},
+        )
+
+        assert shared == {"A", "B", "C"}
+        assert svc.get_tip_names_from_tree(species_tree) == ["A", "B", "C"]
+        assert all(
+            set(svc.get_tip_names_from_tree(tree)) == shared
+            for tree in pruned_trees
+        )
+
+    def test_shared_mode_requires_three_shared_taxa(self, default_args):
+        svc = ConcordanceAsr(default_args)
+        species_tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        gene_trees = [
+            Phylo.read(StringIO("((A:1,B:1):1,D:1);"), "newick"),
+            Phylo.read(StringIO("((A:1,B:1):1,E:1);"), "newick"),
+        ]
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._normalize_taxa(species_tree, gene_trees, {"A", "B", "C"})
+
+        assert exc_info.value.messages == [
+            "Only 2 shared taxa across species and gene trees.",
+            "At least 3 shared taxa are required.",
+        ]
+
 
 def _make_asr_helper():
     """Create a minimal AncestralReconstruction helper for testing."""
@@ -409,6 +463,92 @@ class TestGCFComputation:
         assert clade_tip_sets[id(species_tree.root)] == frozenset(
             svc.get_tip_names_from_tree(species_tree)
         )
+
+    def test_collect_clade_tip_sets_supports_legacy_tree_interface(self, default_args):
+        svc = ConcordanceAsr(default_args)
+        parsed = Phylo.read(StringIO("((A,B),(C,D));"), "newick")
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return parsed.find_clades(*args, **kwargs)
+
+        clade_tip_sets = svc._collect_clade_tip_sets(LegacyTree())
+
+        assert clade_tip_sets[id(parsed.root)] == frozenset({"A", "B", "C", "D"})
+
+    def test_gcf_computation_supports_legacy_tree_iterators(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        svc._asr = Namespace(_build_parent_map=lambda _tree: {})
+        gene_clade = Namespace()
+        species_tip = Namespace(is_terminal=lambda: True)
+
+        class LegacyGeneTree:
+            def get_nonterminals(self):
+                return [gene_clade]
+
+        class LegacySpeciesTree:
+            def find_clades(self, **_kwargs):
+                return [species_tip]
+
+        gene_tree = LegacyGeneTree()
+        species_tree = LegacySpeciesTree()
+        monkeypatch.setattr(
+            svc,
+            "_collect_clade_tip_sets",
+            lambda tree: (
+                {id(gene_clade): frozenset({"A", "B"})}
+                if tree is gene_tree
+                else {}
+            ),
+        )
+
+        observed = svc._compute_gcf_per_node(
+            species_tree,
+            [gene_tree],
+            {"A", "B", "C", "D"},
+        )
+
+        assert observed == {}
+
+    def test_gcf_defaults_to_concordant_when_no_topology_is_observed(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        svc._asr = _make_asr_helper()
+        species_tree = svc.read_tree_file()
+        gene_trees = svc._parse_gene_trees(GENE_TREES)
+        monkeypatch.setattr(
+            svc,
+            "_count_gcf_topologies",
+            lambda *_args: (0, 0, 0),
+        )
+
+        result = svc._compute_gcf_per_node(
+            species_tree,
+            gene_trees,
+            set(svc.get_tip_names_from_tree(species_tree)),
+        )
+
+        assert result
+        assert all(value == (1.0, 0.0, 0.0) for value in result.values())
+
+    def test_four_group_decomposition_rejects_node_without_siblings(
+        self, default_args
+    ):
+        svc = ConcordanceAsr(default_args)
+        children = [Namespace(), Namespace()]
+        node = Namespace(is_terminal=lambda: False, clades=children)
+        parent = Namespace(clades=[node])
+
+        assert svc._get_four_groups(
+            Namespace(),
+            node,
+            {id(node): parent},
+            frozenset({"A", "B", "C", "D"}),
+            {id(children[0]): {"A"}, id(children[1]): {"B"}},
+        ) is None
 
     def test_gcf_fractions(self, default_args):
         svc = ConcordanceAsr(default_args)
@@ -686,6 +826,24 @@ class TestCachedDescendantAssembly:
 
 
 class TestNNIAlternatives:
+    def test_root_and_unpaired_nodes_have_no_nni_alternatives(self, default_args):
+        svc = ConcordanceAsr(default_args)
+        species_tree = svc.read_tree_file()
+
+        assert svc._build_nni_alternative_at_node(
+            species_tree,
+            species_tree.root,
+            {},
+        ) == []
+
+        target = Namespace(clades=[Namespace(), Namespace()])
+        parent = Namespace(clades=[target])
+        assert svc._build_nni_alternative_at_node(
+            species_tree,
+            target,
+            {id(target): parent},
+        ) == []
+
     def test_produces_alternatives(self, default_args):
         svc = ConcordanceAsr(default_args)
         svc._asr = _make_asr_helper()
@@ -744,8 +902,6 @@ class TestNNIAlternatives:
         svc._asr = _make_asr_helper()
         species_tree = svc.read_tree_file()
         parent_map = svc._asr._build_parent_map(species_tree)
-        all_taxa = frozenset(t.name for t in species_tree.get_terminals())
-
         for clade in species_tree.find_clades(order="preorder"):
             if clade.is_terminal() or clade == species_tree.root:
                 continue
@@ -830,6 +986,38 @@ class TestLawOfTotalVariance:
 
 
 class TestWeightedMethod:
+    def test_run_asr_on_tree_rejects_fewer_than_three_remaining_tips(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        tree = Namespace()
+        monkeypatch.setattr(svc, "get_tip_names_from_tree", lambda _tree: ["A", "B"])
+        monkeypatch.setattr(
+            svc,
+            "_tips_to_prune_for_ordered_mapping",
+            lambda *_args: [],
+        )
+
+        assert svc._run_asr_on_tree(tree, {"A": 1.0, "B": 2.0}) == ({}, {}, 0.0)
+
+    def test_run_asr_on_tree_rejects_fewer_than_three_trait_matches(
+        self, default_args, monkeypatch
+    ):
+        svc = ConcordanceAsr(default_args)
+        tree = Namespace()
+        monkeypatch.setattr(
+            svc,
+            "get_tip_names_from_tree",
+            lambda _tree: ["A", "B", "C"],
+        )
+        monkeypatch.setattr(
+            svc,
+            "_tips_to_prune_for_ordered_mapping",
+            lambda *_args: [],
+        )
+
+        assert svc._run_asr_on_tree(tree, {"A": 1.0, "B": 2.0}) == ({}, {}, 0.0)
+
     def test_run_asr_on_tree_uses_fast_tip_name_helper_without_pruning(
         self, default_args, mocker
     ):
@@ -894,7 +1082,6 @@ class TestWeightedMethod:
         species_tree = svc.read_tree_file()
         gene_trees = svc._parse_gene_trees(GENE_TREES)
         all_taxa = set(t.name for t in species_tree.get_terminals())
-        from phykit.services.tree.ancestral_reconstruction import AncestralReconstruction
         trait_values = svc._asr._parse_single_trait_data(TRAITS_FILE, sorted(all_taxa))
 
         result = svc._run_weighted(species_tree, gene_trees, trait_values, all_taxa)
@@ -1535,10 +1722,7 @@ class TestCircularPlot:
 
     def test_concordance_asr_circular(self):
         """--circular flag produces a circular layout concordance ASR plot."""
-        try:
-            import matplotlib
-        except ImportError:
-            pytest.skip("matplotlib not installed")
+        pytest.importorskip("matplotlib")
 
         import tempfile
         import os
@@ -1571,6 +1755,20 @@ class TestCircularPlot:
 
 
 class TestEdgeCases:
+    def test_gene_tree_without_branch_lengths_errors(self, tmp_path, default_args):
+        gene_trees = tmp_path / "missing-lengths.nwk"
+        gene_trees.write_text("((A,B),C);\n((A,C),B);\n")
+        default_args.gene_trees = str(gene_trees)
+        svc = ConcordanceAsr(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert exc_info.value.messages == [
+            "Gene tree 1 has branches without lengths.",
+            "All gene trees must have branch lengths.",
+        ]
+
     def test_single_gene_tree_errors(self):
         """Single gene tree should raise error."""
         import tempfile
@@ -1657,7 +1855,6 @@ class TestEdgeCases:
 
     def test_ci_with_weighted(self, ci_args):
         svc = ConcordanceAsr(ci_args)
-        captured = []
         with patch("builtins.print") as mock_print:
             svc.run()
 
@@ -1858,7 +2055,6 @@ class TestBenchmarkVerification:
         )
 
         # Run components manually
-        node_labels = svc._asr._label_internal_nodes(species_tree)
         parent_map = svc._asr._build_parent_map(species_tree)
         gcf_per_node = svc._compute_gcf_per_node(
             species_tree, gene_trees, all_taxa

--- a/tests/unit/services/tree/test_consensus_network.py
+++ b/tests/unit/services/tree/test_consensus_network.py
@@ -106,6 +106,10 @@ def test_shared_tip_set_stops_when_empty():
     ) == set()
 
 
+def test_empty_tip_set_collection_is_vacuously_identical():
+    assert consensus_network_module._all_tip_sets_identical([])
+
+
 def test_lazy_phylo_caches_resolved_read(monkeypatch):
     calls = []
 
@@ -872,6 +876,33 @@ class TestNetworkPlot:
 
 
 class TestPruneToTaxa:
+    def test_falls_back_to_generic_terminal_pruning(self, monkeypatch):
+        tree = _make_tree("((A,B),(C,D));")
+        original_prune = tree.prune
+        pruned_names = []
+
+        monkeypatch.setattr(
+            consensus_network_module.Tree,
+            "calculate_terminal_clades_fast",
+            lambda _tree: None,
+        )
+        monkeypatch.setattr(
+            consensus_network_module.Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            lambda _tree, _target_ids: False,
+        )
+
+        def tracking_prune(tip):
+            pruned_names.append(tip.name)
+            return original_prune(tip)
+
+        monkeypatch.setattr(tree, "prune", tracking_prune)
+
+        ConsensusNetwork._prune_to_taxa(tree, {"A", "C"})
+
+        assert pruned_names == ["B", "D"]
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "C"}
+
     def test_avoids_generic_terminal_collection(self, monkeypatch):
         tree = _make_tree("((A,B),(C,D));")
         original_get_terminals = tree.get_terminals
@@ -906,6 +937,132 @@ class TestPruneToTaxa:
 
 
 class TestConsensusNetworkRun:
+    def test_parse_trees_reports_missing_source(self, tmp_path):
+        missing_path = tmp_path / "missing-trees.nwk"
+        svc = ConsensusNetwork(
+            Namespace(
+                trees=str(missing_path),
+                threshold=0.1,
+                missing_taxa="error",
+                plot_output=None,
+                json=False,
+            )
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(missing_path))
+
+        assert f"{missing_path} corresponds to no such file or directory." in (
+            exc_info.value.messages
+        )
+
+    def test_parse_trees_rejects_empty_source(self, tmp_path):
+        tree_file = tmp_path / "empty-trees.nwk"
+        _write(tree_file, "\n# comments only\n")
+        svc = ConsensusNetwork(
+            Namespace(
+                trees=str(tree_file),
+                threshold=0.1,
+                missing_taxa="error",
+                plot_output=None,
+                json=False,
+            )
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert "No trees found in input." in exc_info.value.messages
+
+    def test_parse_trees_wraps_newick_parser_errors(self, tmp_path, monkeypatch):
+        tree_file = tmp_path / "malformed-trees.nwk"
+        _write(tree_file, "(not-valid);\n")
+        svc = ConsensusNetwork(
+            Namespace(
+                trees=str(tree_file),
+                threshold=0.1,
+                missing_taxa="error",
+                plot_output=None,
+                json=False,
+            )
+        )
+        monkeypatch.setattr(
+            consensus_network_module.Phylo,
+            "read",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad tree")),
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert "Failed to parse Newick trees: bad tree" in exc_info.value.messages
+
+    def test_parse_tree_list_reports_missing_entry(self, tmp_path):
+        tree_list = tmp_path / "tree-list.txt"
+        _write(tree_list, "missing-tree.nwk\n")
+        svc = ConsensusNetwork(
+            Namespace(
+                trees=str(tree_list),
+                threshold=0.1,
+                missing_taxa="error",
+                plot_output=None,
+                json=False,
+            )
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_list))
+
+        expected_path = tmp_path / "missing-tree.nwk"
+        assert f"{expected_path} corresponds to no such file or directory." in (
+            exc_info.value.messages
+        )
+
+    def test_tip_collection_falls_back_for_nonstandard_tree(self, monkeypatch):
+        tree = _make_tree("((A,B),C);")
+        monkeypatch.setattr(
+            consensus_network_module.Tree,
+            "calculate_terminal_names_fast",
+            lambda _tree: None,
+        )
+
+        assert ConsensusNetwork._tips(tree) == {"A", "B", "C"}
+
+    @pytest.mark.parametrize(
+        ("missing_taxa", "newicks", "message"),
+        [
+            (
+                "allow",
+                ["(A,B);", "A;"],
+                "Fewer than 3 taxa found across all trees.",
+            ),
+            (
+                "shared",
+                ["((A,B),C);", "((A,B),D);"],
+                "At least 3 shared taxa are required.",
+            ),
+        ],
+        ids=["allow-union", "shared-intersection"],
+    )
+    def test_normalize_taxa_requires_three_taxa(
+        self, missing_taxa, newicks, message
+    ):
+        svc = ConsensusNetwork(
+            Namespace(
+                trees="unused",
+                threshold=0.1,
+                missing_taxa=missing_taxa,
+                plot_output=None,
+                json=False,
+            )
+        )
+        trees = [_make_tree(newick) for newick in newicks]
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._normalize_taxa(trees)
+
+        assert message in exc_info.value.messages
+
     def test_parse_trees_skips_comments_and_blank_lines(self, tmp_path):
         tree_file = tmp_path / "trees.nwk"
         _write(

--- a/tests/unit/services/tree/test_cont_map.py
+++ b/tests/unit/services/tree/test_cont_map.py
@@ -228,6 +228,30 @@ class TestTraitParsing:
 
 
 class TestRun:
+    def test_circular_color_annotations_render(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        color_file = tmp_path / "colors.tsv"
+        color_file.write_text(
+            "raccoon,bear\trange\t#ffcc00\tHighlighted taxa\n"
+            "raccoon\tlabel\t#0033cc\n"
+        )
+        output = tmp_path / "cont-map-circular.png"
+        svc = ContMap(
+            Namespace(
+                tree=TREE_SIMPLE,
+                trait_data=TRAITS_FILE,
+                output=str(output),
+                json=False,
+                circular=True,
+                color_file=str(color_file),
+            )
+        )
+
+        svc.run()
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
     def test_run_all_tips_present_uses_read_only_tree_without_copy_or_prune(
         self, mocker
     ):

--- a/tests/unit/services/tree/test_cont_map.py
+++ b/tests/unit/services/tree/test_cont_map.py
@@ -82,6 +82,15 @@ class TestProcessArgs:
 
 
 class TestTraitParsing:
+    def test_missing_file_reports_path(self, tmp_path):
+        missing = tmp_path / "missing.tsv"
+        svc = ContMap.__new__(ContMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_single_trait_data(str(missing), ["A", "B", "C"])
+
+        assert str(missing) in exc_info.value.messages[0]
+
     def test_comments_and_blanks(self, tmp_path):
         trait_file = tmp_path / "traits.tsv"
         trait_file.write_text(
@@ -173,6 +182,49 @@ class TestTraitParsing:
             "Non-numeric trait value 'bad' for taxon 'bear' on line 2."
             in exc_info.value.messages
         )
+
+    def test_unordered_exact_taxa_emit_no_warnings(self, tmp_path, capsys):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("C\t3.0\nA\t1.0\nB\t2.0\n")
+        svc = ContMap.__new__(ContMap)
+
+        traits = svc._parse_single_trait_data(
+            str(trait_file), ["A", "B", "C"]
+        )
+
+        assert traits == {"C": 3.0, "A": 1.0, "B": 2.0}
+        assert capsys.readouterr().err == ""
+
+    def test_taxon_mismatches_warn_and_return_shared_values(
+        self, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nC\t3.0\nextra\t4.0\n")
+        svc = ContMap.__new__(ContMap)
+
+        traits = svc._parse_single_trait_data(
+            str(trait_file), ["A", "B", "C", "missing"]
+        )
+
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        stderr = capsys.readouterr().err
+        assert "missing" in stderr
+        assert "extra" in stderr
+
+    def test_too_few_shared_taxa_are_rejected(self, tmp_path, capsys):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nextra\t3.0\n")
+        svc = ContMap.__new__(ContMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_single_trait_data(
+                str(trait_file), ["A", "B", "missing"]
+            )
+
+        assert "Only 2 shared taxa" in exc_info.value.messages[0]
+        stderr = capsys.readouterr().err
+        assert "missing" in stderr
+        assert "extra" in stderr
 
 
 class TestRun:
@@ -420,6 +472,14 @@ class TestRun:
 
 
 class TestFastAnc:
+    def test_internal_labels_preserve_existing_names(self):
+        svc = ContMap.__new__(ContMap)
+        tree = Phylo.read(StringIO("(A:1,B:1)ancestor;"), "newick")
+
+        labels = svc._label_internal_nodes(tree)
+
+        assert labels[id(tree.root)] == "ancestor"
+
     def test_iter_postorder_matches_biopython_order(self):
         svc = ContMap.__new__(ContMap)
         tree = Phylo.read(
@@ -493,6 +553,21 @@ class TestFastAnc:
         assert set(estimates) == {"N1", "N2", "N3"}
         assert sigma2 > 0
 
+    def test_fast_anc_handles_missing_tip_and_zero_length_branches(self):
+        svc = ContMap.__new__(ContMap)
+        tree = Phylo.read(StringIO("(A:0,B:0);"), "newick")
+        labels = svc._label_internal_nodes(tree)
+
+        estimates, sigma2 = svc._fast_anc(
+            tree,
+            np.array([5.0]),
+            ["A"],
+            labels,
+        )
+
+        assert estimates[labels[id(tree.root)]] == pytest.approx(5.0)
+        assert sigma2 == 0.0
+
     def test_sigma2_from_contrasts_handles_polytomy(self):
         svc = ContMap.__new__(ContMap)
         tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
@@ -516,6 +591,21 @@ class TestFastAnc:
         combined_var = 0.5
         expected_second = ((3.0 - combined_est) ** 2) / (1.0 + combined_var)
         assert sigma2 == pytest.approx((expected_first + expected_second) / 2.0)
+
+    def test_sigma2_handles_missing_and_zero_variance_children(self):
+        svc = ContMap.__new__(ContMap)
+        tree = Phylo.read(StringIO("(A:0,B:0,C:0);"), "newick")
+        a, b, _c = tree.root.clades
+
+        sigma2 = svc._compute_sigma2_from_contrasts(
+            tree,
+            np.array([1.0, 1.0]),
+            {id(a): 1.0, id(b): 1.0},
+            {id(a): 0.0, id(b): 0.0},
+            ["A", "B"],
+        )
+
+        assert sigma2 == 0.0
 
 
 class TestPlotContMap:
@@ -643,6 +733,34 @@ class TestPlotContMap:
         )
 
         assert arcs == [(0, 0, 5.0, 1.0, 2.0, 3.0)]
+
+    def test_contmap_scalar_arcs_skip_incomplete_nodes(self):
+        missing_coord = Clade(clades=[Clade(name="A"), Clade(name="B")])
+        missing_estimate = Clade(clades=[Clade(name="C"), Clade(name="D")])
+        missing_child_coord = Clade(
+            clades=[Clade(name="E"), Clade(name="F")]
+        )
+        polytomy = Clade(
+            clades=[Clade(name="G"), Clade(name="H"), Clade(name="I")]
+        )
+        coords = {
+            id(missing_estimate): {"radius": 1.0, "angle": 0.0},
+            id(missing_child_coord): {"radius": 2.0, "angle": 0.0},
+            id(missing_child_coord.clades[0]): {"radius": 3.0, "angle": 0.5},
+            id(polytomy): {"radius": 4.0, "angle": 0.0},
+            id(polytomy.clades[0]): {"radius": 5.0, "angle": 1.0},
+        }
+        estimates = {
+            id(missing_coord): 1.0,
+            id(missing_child_coord): 2.0,
+            id(polytomy): 3.0,
+        }
+
+        assert ContMap._contmap_scalar_arcs(
+            [missing_coord, missing_estimate, missing_child_coord, polytomy],
+            coords,
+            estimates,
+        ) == []
 
     def test_iter_preorder_preserves_order_without_reversed(self):
         class NoReversedList(list):

--- a/tests/unit/services/tree/test_cophylo.py
+++ b/tests/unit/services/tree/test_cophylo.py
@@ -119,8 +119,117 @@ class TestMappingParsing:
         with pytest.raises(PhykitUserError):
             svc._parse_mapping_file(str(mapping_file))
 
+    def test_mapping_file_reports_missing_path(self, tmp_path):
+        svc = Cophylo.__new__(Cophylo)
+        missing = tmp_path / "missing.tsv"
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_mapping_file(str(missing))
+
+        assert "no such file or directory" in exc_info.value.messages[0]
+
 
 class TestRun:
+    def test_run_reports_second_tree_read_failure(self, mocker):
+        svc = Cophylo(
+            Namespace(
+                tree1=TREE1,
+                tree2="missing.tre",
+                output="out.png",
+                mapping=None,
+                json=False,
+            )
+        )
+        mocker.patch.object(
+            svc,
+            "_read_prepared_tree",
+            side_effect=[object(), ValueError("invalid tree")],
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert "missing.tre" in exc_info.value.messages[0]
+
+    def test_run_filters_mapping_and_ladderizes_both_trees(self, mocker):
+        svc = Cophylo(
+            Namespace(
+                tree1=TREE1,
+                tree2=TREE2,
+                output="out.png",
+                mapping="mapping.tsv",
+                json=False,
+                ladderize=True,
+            )
+        )
+        tree1 = mocker.Mock()
+        tree2 = mocker.Mock()
+        mocker.patch.object(
+            svc,
+            "_read_prepared_tree",
+            side_effect=[tree1, tree2],
+        )
+        mocker.patch.object(
+            svc,
+            "get_tip_names_from_tree",
+            side_effect=[["A", "B"], ["X", "Y"]],
+        )
+        mocker.patch.object(
+            svc,
+            "_parse_mapping_file",
+            return_value={"A": "X", "B": "Y", "missing": "Y"},
+        )
+        optimize = mocker.patch.object(
+            svc,
+            "_optimize_tip_order",
+            return_value=({"A": 0, "B": 1}, {"X": 0, "Y": 1}),
+        )
+        plot = mocker.patch.object(svc, "_plot_cophylo")
+        mocker.patch.object(svc, "_print_text_output")
+
+        svc.run()
+
+        tree1.ladderize.assert_called_once_with()
+        tree2.ladderize.assert_called_once_with()
+        optimize.assert_called_once_with(
+            tree1,
+            tree2,
+            {"A": "X", "B": "Y"},
+            mutate_tree2=True,
+        )
+        plot.assert_called_once()
+
+    def test_run_rejects_mapping_with_too_few_valid_taxa(self, mocker):
+        svc = Cophylo(
+            Namespace(
+                tree1=TREE1,
+                tree2=TREE2,
+                output="out.png",
+                mapping="mapping.tsv",
+                json=False,
+            )
+        )
+        mocker.patch.object(
+            svc,
+            "_read_prepared_tree",
+            side_effect=[object(), object()],
+        )
+        mocker.patch.object(
+            svc,
+            "get_tip_names_from_tree",
+            side_effect=[["A", "B"], ["X", "Y"]],
+        )
+        mocker.patch.object(
+            svc,
+            "_parse_mapping_file",
+            return_value={"A": "X", "B": "missing"},
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert exc_info.value.messages[0].startswith("Only 1 valid mapped taxa")
+
     def test_run_prepares_both_trees_without_forcing_rectangular_copies(self, mocker):
         args = Namespace(
             tree1=TREE1,
@@ -325,6 +434,104 @@ class TestRun:
         assert Cophylo._validate_standard_tree(tree) == 6
         assert tree.root.branch_length is None
         assert tree.root.clades[1].clades[1].branch_length == 1.0
+
+    def test_validate_tree_supports_generic_tree_protocol(self):
+        class GenericClade:
+            def __init__(self, name, branch_length=None, children=()):
+                self.name = name
+                self.branch_length = branch_length
+                self.clades = list(children)
+
+        tips = [GenericClade("A"), GenericClade("B", branch_length=2.0)]
+
+        class GenericTree:
+            root = object()
+
+            def get_terminals(self):
+                return tips
+
+            def find_clades(self, order=None):
+                return iter(tips)
+
+        tree = GenericTree()
+        svc = Cophylo.__new__(Cophylo)
+
+        assert svc._validate_tree(tree, "generic tree") is True
+        assert tips[0].branch_length == 1.0
+        assert tips[1].branch_length == 2.0
+        assert Cophylo._validate_standard_tree(tree) is None
+
+    def test_validate_tree_rejects_generic_single_tip_tree(self):
+        tip = Namespace(name="A", branch_length=1.0, clades=[])
+
+        class GenericTree:
+            root = object()
+
+            def get_terminals(self):
+                return [tip]
+
+            def find_clades(self, order=None):
+                return iter([tip])
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            Cophylo.__new__(Cophylo)._validate_tree(GenericTree(), "tree")
+
+        assert "at least 2 tips" in exc_info.value.messages[0]
+
+    def test_standard_tree_validation_handles_malformed_child(self):
+        malformed = Namespace(root=Namespace(clades=[object()]))
+
+        assert Cophylo._validate_standard_tree(malformed) is None
+
+    def test_traversal_helpers_fall_back_for_generic_tree(self):
+        tip_a = Namespace(name="A", clades=[])
+        tip_b = Namespace(name="B", clades=[])
+        internal = Namespace(name=None, clades=[tip_a, tip_b])
+
+        class GenericTree:
+            root = object()
+
+            def find_clades(self, order=None):
+                if order == "postorder":
+                    return iter([tip_a, tip_b, internal])
+                return iter([internal, tip_a, tip_b])
+
+            def get_terminals(self):
+                return [tip_a, tip_b]
+
+        tree = GenericTree()
+        svc = Cophylo.__new__(Cophylo)
+
+        assert svc._build_parent_map(tree) == {
+            id(tip_a): internal,
+            id(tip_b): internal,
+        }
+        assert Cophylo._preorder_clades(tree) == [internal, tip_a, tip_b]
+        assert Cophylo._postorder_clades(tree) == [tip_a, tip_b, internal]
+        assert Cophylo._terminal_clades(tree) == [tip_a, tip_b]
+
+    @pytest.mark.parametrize(
+        ("helper", "expected"),
+        [
+            (Cophylo._preorder_clades, "preorder"),
+            (Cophylo._postorder_clades, "postorder"),
+            (Cophylo._terminal_clades, "terminals"),
+        ],
+    )
+    def test_traversal_helpers_recover_from_malformed_child(self, helper, expected):
+        root = Namespace(clades=[object()])
+
+        class MalformedTree:
+            def __init__(self):
+                self.root = root
+
+            def find_clades(self, order=None):
+                return [expected]
+
+            def get_terminals(self):
+                return [expected]
+
+        assert helper(MalformedTree()) == [expected]
 
     def test_get_tip_order_uses_fast_terminal_names_for_parsed_tree(
         self, monkeypatch

--- a/tests/unit/services/tree/test_dtt.py
+++ b/tests/unit/services/tree/test_dtt.py
@@ -83,6 +83,44 @@ def test_observed_postorder_disparity_threshold_targets_larger_work():
     assert _should_use_observed_postorder_disparities(np.empty((8192, 2)))
 
 
+def test_observed_postorder_disparities_reject_incomplete_contexts():
+    data = np.array([[1.0, 2.0]])
+
+    assert _observed_avg_sq_clade_disparities(data, {}) is None
+
+    context = {
+        "postorder_clade_ids": [10, 20, 30],
+        "terminal_index_by_clade_id": {20: 0},
+        "child_clade_ids": {10: (999,), 30: (20, 999)},
+        "clade_index_arrays": {},
+    }
+
+    assert _observed_avg_sq_clade_disparities(data, context) == {}
+
+
+def test_tree_depth_and_traversal_helpers_reject_incompatible_objects():
+    class MissingRootDepth:
+        root = object()
+
+        @staticmethod
+        def depths():
+            return {}
+
+    class MalformedChild:
+        branch_length = 1.0
+
+    class MalformedRoot:
+        clades = [MalformedChild()]
+
+    class MalformedTree:
+        root = MalformedRoot()
+
+    assert Dtt._root_relative_depths(object()) is None
+    assert Dtt._root_relative_depths(MissingRootDepth()) is None
+    assert Dtt._standard_dtt_traversal_context(object()) is None
+    assert Dtt._standard_dtt_traversal_context(MalformedTree()) is None
+
+
 def test_permutation_p_value_ge_counts_extreme_permutations(monkeypatch):
     permutations = np.array([0.5, 1.5, 2.5, 3.5])
     original_count_nonzero = dtt_module.np.count_nonzero
@@ -341,6 +379,67 @@ class TestComputeDisparity:
 
 
 class TestComputeDtt:
+    def test_prepare_context_supports_generic_tree_traversal(self, monkeypatch):
+        svc = Dtt(_make_args())
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        monkeypatch.setattr(
+            svc,
+            "_standard_dtt_traversal_context",
+            lambda _tree: None,
+        )
+
+        context = svc._prepare_dtt_context(tree, ["A", "B", "C"])
+
+        assert not context["zero_height"]
+        assert context["times"][0] == pytest.approx(0.0)
+        assert context["clade_index_arrays"]
+
+    def test_prepare_context_can_compute_depths_from_distances(self, monkeypatch):
+        svc = Dtt(_make_args())
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        monkeypatch.setattr(
+            svc,
+            "_standard_dtt_traversal_context",
+            lambda _tree: None,
+        )
+        monkeypatch.setattr(svc, "_root_relative_depths", lambda _tree: None)
+
+        context = svc._prepare_dtt_context(tree, ["A", "B", "C"])
+
+        assert not context["zero_height"]
+        assert context["times"][0] == pytest.approx(0.0)
+        assert context["clade_index_arrays"]
+
+    def test_identical_traits_return_boundary_curve(self):
+        svc = Dtt(_make_args())
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        data = np.ones((3, 1))
+
+        times, values = svc._compute_dtt(tree, data, ["A", "B", "C"])
+
+        assert times == [0.0, 1.0]
+        assert values == [1.0, 0.0]
+
+    def test_positive_terminal_disparity_adds_zero_boundary(self):
+        svc = Dtt(_make_args())
+        data = np.array([[0.0], [1.0], [3.0]])
+        context = {
+            "zero_height": False,
+            "times": [0.0, 0.5],
+            "lineage_clade_ids": [[1]],
+            "clade_index_arrays": {1: np.asarray([0, 1], dtype=np.intp)},
+        }
+
+        times, values = svc._compute_dtt(
+            None,
+            data,
+            ["A", "B", "C"],
+            context=context,
+        )
+
+        assert times == [0.0, 0.5, 1.0]
+        assert values[-1] == pytest.approx(0.0)
+
     def test_dtt_starts_at_one(self):
         """DTT curve should start with relative disparity = 1.0 at time 0."""
         args = _make_args()
@@ -1017,6 +1116,41 @@ class TestRun:
 
 
 class TestSimulateNull:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            np.array([[0.0], [1.0], [2.0], [4.0]]),
+            np.array(
+                [[0.0, 1.0], [1.0, 0.0], [2.0, 3.0], [4.0, 2.0]]
+            ),
+        ],
+        ids=["single-trait", "multi-trait"],
+    )
+    def test_manhattan_simulation_handles_singular_covariance(
+        self, data, monkeypatch
+    ):
+        svc = Dtt(_make_args(index="avg_manhattan", nsim=3, seed=7))
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        ordered_names = ["A", "B", "C", "D"]
+        obs_times, obs_values = svc._compute_dtt(tree, data, ordered_names)
+        monkeypatch.setattr(
+            "phykit.services.tree.vcv_utils.build_vcv_matrix",
+            lambda _tree, _names: np.zeros((4, 4)),
+        )
+
+        sim_dtt, mdi, mdi_p = svc._simulate_null(
+            tree,
+            data,
+            ordered_names,
+            obs_times,
+            obs_values,
+        )
+
+        assert sim_dtt.shape == (3, len(obs_times))
+        assert np.isfinite(sim_dtt).all()
+        assert np.isfinite(mdi)
+        assert 0.0 <= mdi_p <= 1.0
+
     def test_avg_sq_batch_simulation_matches_scalar_loop(self):
         args = _make_args(trait="body_mass", nsim=5, seed=42)
         svc = Dtt(args)

--- a/tests/unit/services/tree/test_hybridization.py
+++ b/tests/unit/services/tree/test_hybridization.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 
 import pytest
 from argparse import Namespace
@@ -217,6 +216,16 @@ class TestPerBranchCounts:
 
         assert len(trees) == 1
 
+    def test_parse_gene_trees_reports_missing_input(self, tmp_path):
+        missing_path = tmp_path / "missing_gene_trees.nwk"
+        svc = _make_svc(gene_trees=str(missing_path))
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_gene_trees(str(missing_path))
+
+        assert exc_info.value.code == 2
+        assert str(missing_path) in exc_info.value.messages[0]
+
     def test_parse_gene_tree_path_list_avoids_per_row_path_objects(
         self, tmp_path, monkeypatch
     ):
@@ -413,6 +422,177 @@ class TestPerBranchCounts:
 
         assert [tip.name for tip in tips] == ["A", "B", "C", "D", "E", "F"]
 
+    def test_tree_helpers_support_traversal_only_interface(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        source_tree = Phylo.read(
+            StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick"
+        )
+
+        class TraversalOnlyTree:
+            def find_clades(self, order):
+                return source_tree.find_clades(order=order)
+
+            def get_terminals(self):
+                return source_tree.get_terminals()
+
+        tree = TraversalOnlyTree()
+
+        parent_map = svc._build_parent_map(tree)
+        preorder = svc._preorder_clades(tree)
+        postorder = svc._postorder_clades(tree)
+        clade_taxa = svc._collect_clade_taxa(tree)
+        terminals = svc._get_terminal_clades(tree)
+
+        assert len(parent_map) == 6
+        assert preorder == list(source_tree.find_clades(order="preorder"))
+        assert postorder == list(source_tree.find_clades(order="postorder"))
+        assert clade_taxa[id(source_tree.root)] == frozenset({"A", "B", "C", "D"})
+        assert terminals == source_tree.get_terminals()
+
+    def test_tree_helpers_fall_back_from_incomplete_direct_interface(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        source_tree = Phylo.read(
+            StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick"
+        )
+        malformed_root = type("Root", (), {"clades": [object()]})()
+
+        class AdaptedTree:
+            root = malformed_root
+
+            def find_clades(self, order):
+                return source_tree.find_clades(order=order)
+
+            def get_terminals(self):
+                return source_tree.get_terminals()
+
+        tree = AdaptedTree()
+
+        assert len(svc._build_parent_map(tree)) == 6
+        assert svc._preorder_clades(tree) == list(
+            source_tree.find_clades(order="preorder")
+        )
+        assert svc._postorder_clades(tree) == list(
+            source_tree.find_clades(order="postorder")
+        )
+        clade_taxa = svc._collect_clade_taxa(tree)
+        assert clade_taxa[id(source_tree.root)] == frozenset({"A", "B", "C", "D"})
+        assert svc._get_terminal_clades(tree) == source_tree.get_terminals()
+
+    def test_tree_helpers_preserve_unary_clade_taxa(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        tree = Phylo.read(StringIO("(((A:1):1,B:1):1,C:1);"), "newick")
+        unary = tree.root.clades[0].clades[0]
+
+        preorder = svc._preorder_clades(tree)
+        clade_taxa = svc._collect_clade_taxa(tree)
+
+        assert unary in preorder
+        assert clade_taxa[id(unary)] == frozenset({"A"})
+
+    def test_get_four_groups_computes_taxa_when_cache_is_omitted(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        tree = Phylo.read(
+            StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick"
+        )
+
+        groups = svc._get_four_groups(
+            tree,
+            tree.root.clades[0],
+            svc._build_parent_map(tree),
+            frozenset({"A", "B", "C", "D"}),
+        )
+
+        assert groups == tuple(frozenset({taxon}) for taxon in "ABCD")
+
+    def test_get_four_groups_rejects_uninformative_branches(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        balanced = Phylo.read(
+            StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick"
+        )
+        parent_map = svc._build_parent_map(balanced)
+        clade_taxa = svc._collect_clade_taxa(balanced)
+        left = balanced.root.clades[0]
+
+        assert svc._get_four_groups(
+            balanced,
+            left.clades[0],
+            parent_map,
+            frozenset({"A", "B", "C", "D"}),
+            clade_taxa,
+        ) is None
+
+        unary_tree = Phylo.read(StringIO("((A:1):1,(B:1,C:1):1);"), "newick")
+        unary = unary_tree.root.clades[0]
+        assert svc._get_four_groups(
+            unary_tree,
+            unary,
+            svc._build_parent_map(unary_tree),
+            frozenset({"A", "B", "C"}),
+            svc._collect_clade_taxa(unary_tree),
+        ) is None
+
+        parent_without_sibling = type("Parent", (), {"clades": [left]})()
+        assert svc._get_four_groups(
+            balanced,
+            left,
+            {id(left): parent_without_sibling},
+            frozenset({"A", "B"}),
+            clade_taxa,
+        ) is None
+
+    def test_get_four_groups_rejects_filtered_or_terminal_siblings(self):
+        from Bio import Phylo
+        from io import StringIO
+
+        svc = _make_svc()
+        terminal_sibling = Phylo.read(
+            StringIO("((A:1,B:1):1,C:1);"), "newick"
+        )
+        left = terminal_sibling.root.clades[0]
+        parent_map = svc._build_parent_map(terminal_sibling)
+        clade_taxa = svc._collect_clade_taxa(terminal_sibling)
+
+        assert svc._get_four_groups(
+            terminal_sibling,
+            left,
+            parent_map,
+            frozenset({"A", "B"}),
+            clade_taxa,
+        ) is None
+        assert svc._get_four_groups(
+            terminal_sibling,
+            left,
+            parent_map,
+            frozenset({"A", "B", "C"}),
+            clade_taxa,
+        ) is None
+
+        balanced = Phylo.read(
+            StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick"
+        )
+        assert svc._get_four_groups(
+            balanced,
+            balanced.root.clades[0],
+            svc._build_parent_map(balanced),
+            frozenset({"B", "C", "D"}),
+            svc._collect_clade_taxa(balanced),
+        ) is None
+
 
 class TestAsymmetryRatioRange:
     def test_asymmetry_ratio_range(self):
@@ -516,6 +696,40 @@ class TestReticulationCountNonneg:
                 assert count >= 0
                 break
 
+    def test_run_marks_fdr_significant_asymmetry_as_reticulation(self):
+        svc = _make_svc(alpha=0.05)
+        topology_counts = {
+            "A,B": {
+                "split": ["A", "B"],
+                "n_concordant": 2,
+                "n_alt1": 10,
+                "n_alt2": 0,
+            }
+        }
+        captured = {}
+
+        def capture_output(branch_results, summary):
+            captured["branches"] = branch_results
+            captured["summary"] = summary
+
+        with patch.object(
+            svc, "read_tree_file_unmodified", return_value=object()
+        ), patch.object(
+            svc, "_parse_gene_trees", return_value=[object()] * 12
+        ), patch.object(
+            svc,
+            "_count_topologies",
+            return_value=(topology_counts, frozenset({"A", "B", "C", "D"})),
+        ), patch.object(
+            svc, "_output_text", side_effect=capture_output
+        ):
+            svc.run()
+
+        branch = captured["branches"][0]
+        assert branch["significant"] is True
+        assert branch["hybrid_score"] == pytest.approx(1.0)
+        assert captured["summary"]["n_reticulations"] == 1
+
 
 class TestSupportThreshold:
     def test_support_threshold(self):
@@ -538,9 +752,6 @@ class TestSupportThreshold:
 
     def test_support_threshold_with_supported_trees(self, tmp_path):
         """Test with gene trees that have support values."""
-        from Bio import Phylo
-        from io import StringIO
-
         sp_file = tmp_path / "species.tre"
         sp_file.write_text("((a,b),(c,d));")
 
@@ -678,6 +889,23 @@ class TestTextOutput:
         ])
         assert printed == [((expected,), {})]
 
+    def test_output_text_allows_closed_output_pipe(self, monkeypatch):
+        svc = _make_svc()
+        summary = {
+            "n_branches": 0,
+            "n_gene_trees": 0,
+            "support_threshold": None,
+            "n_reticulations": 0,
+            "alpha": 0.05,
+        }
+
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BrokenPipeError),
+        )
+
+        svc._output_text([], summary)
+
 
 class TestJsonOutput:
     def test_json_output(self, capsys):
@@ -713,6 +941,18 @@ class TestPlotCreated:
         output = str(tmp_path / "test_hybrid.png")
         svc = _make_svc(plot_output=output)
         svc.run()
+        assert os.path.exists(output)
+        assert os.path.getsize(output) > 0
+
+    def test_cladogram_plot_created(self, tmp_path):
+        output = str(tmp_path / "test_hybrid_cladogram.png")
+        args = _make_args(plot_output=output)
+        args.cladogram = True
+        from phykit.services.tree.hybridization import Hybridization
+
+        svc = Hybridization(args)
+        svc.run()
+
         assert os.path.exists(output)
         assert os.path.getsize(output) > 0
 

--- a/tests/unit/services/tree/test_independent_contrasts.py
+++ b/tests/unit/services/tree/test_independent_contrasts.py
@@ -15,10 +15,12 @@ import subprocess
 import sys
 import builtins
 import json
+import math
 from argparse import Namespace
 from pathlib import Path
 from Bio.Phylo.BaseTree import TreeMixin
 
+from phykit.errors import PhykitUserError
 from phykit.services.tree.independent_contrasts import IndependentContrasts
 import phykit.services.tree.independent_contrasts as ic_module
 
@@ -423,6 +425,52 @@ class TestPICComputation:
         assert len(fallback_tree.root.clades) == 2
         assert all(len(clade.clades) <= 2 for clade in fallback_tree.find_clades())
 
+    def test_malformed_polytomy_traversal_delegates_to_fallback(self, args):
+        from Bio import Phylo
+        from io import StringIO
+
+        fallback_tree = Phylo.read(
+            StringIO("(A:1,B:1,C:1,D:1);"), "newick"
+        )
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+            def find_clades(self, *call_args, **kwargs):
+                return fallback_tree.find_clades(*call_args, **kwargs)
+
+        ic = IndependentContrasts(args)
+
+        ic._resolve_polytomies(MalformedTree())
+
+        assert len(fallback_tree.root.clades) == 2
+
+    def test_standard_pic_builders_decline_legacy_tree(self, args):
+        ic = IndependentContrasts(args)
+
+        assert ic._compute_pic_standard_tree(object(), {}) is None
+        assert ic._compute_pic_text_summaries_standard_tree(object(), {}) is None
+
+    def test_standard_pic_builders_skip_unresolved_or_missing_nodes(self, args):
+        from Bio import Phylo
+        from io import StringIO
+
+        ic = IndependentContrasts(args)
+        polytomy = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        missing_tip = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+
+        assert ic._compute_pic_standard_tree(polytomy, {"A": 1.0}) == ([], [])
+        assert ic._compute_pic_standard_tree(missing_tip, {"A": 1.0}) == ([], [])
+        assert ic._compute_pic_text_summaries_standard_tree(
+            polytomy, {"A": 1.0}
+        ) == ([], [])
+        assert ic._compute_pic_text_summaries_standard_tree(
+            missing_tip, {"A": 1.0}
+        ) == ([], [])
+
     def test_direct_postorder_preserves_left_to_right_order(self):
         from Bio import Phylo
         from io import StringIO
@@ -482,6 +530,8 @@ class TestPICComputation:
             (["A", "B"], [], 1, ["A"]),
             (["A", "B"], ["C", "D"], 3, ["A", "B", "C"]),
             (["C", "D"], ["A", "B"], 3, ["A", "B", "C"]),
+            (["C", "D"], ["A", "B"], 2, ["A", "B"]),
+            (["A", "C"], ["B"], 3, ["A", "B", "C"]),
         ],
     )
     def test_limited_label_merge_boundary_cases(
@@ -598,6 +648,47 @@ class TestPICComputation:
 
         assert list(tip_traits) == ["A", "B", "C"]
         assert tip_traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+
+    def test_parse_trait_data_skips_non_numeric_and_malformed_rows(
+        self, monkeypatch, args
+    ):
+        from io import StringIO
+
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *_args, **_kwargs: StringIO(
+                "bad\tnot-a-number\nmalformed\nA\t1\nB\t2\nC\t3\n"
+            ),
+        )
+        ic = IndependentContrasts(args)
+
+        observed = ic._parse_trait_data("traits.tsv", ["A", "B", "C"])
+
+        assert observed == {"A": 1.0, "B": 2.0, "C": 3.0}
+
+    def test_parse_trait_data_reports_missing_file(self, tmp_path, args):
+        ic = IndependentContrasts(args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            ic._parse_trait_data(str(tmp_path / "missing.tsv"), ["A", "B", "C"])
+
+        assert "not found" in excinfo.value.messages[0]
+
+    def test_parse_trait_data_reports_insufficient_shared_taxa(
+        self, monkeypatch, args
+    ):
+        from io import StringIO
+
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *_args, **_kwargs: StringIO("A\t1\nB\t2\n"),
+        )
+        ic = IndependentContrasts(args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            ic._parse_trait_data("traits.tsv", ["A", "B", "C"])
+
+        assert "Only 2 shared taxa" in excinfo.value.messages[0]
 
 
 class TestPICRun:
@@ -829,6 +920,21 @@ class TestPICRun:
         assert mean_abs == pytest.approx(expected_mean_abs)
         assert variance == pytest.approx(expected_variance)
 
+    @pytest.mark.parametrize(
+        ("contrasts", "expected_mean"),
+        [([], float("nan")), ([2.0], 2.0)],
+    )
+    def test_scalar_contrast_summary_handles_fewer_than_two_values(
+        self, contrasts, expected_mean
+    ):
+        mean_abs, variance = ic_module._contrast_summary_stats_scalar(contrasts)
+
+        if math.isnan(expected_mean):
+            assert math.isnan(mean_abs)
+        else:
+            assert mean_abs == expected_mean
+        assert math.isnan(variance)
+
     def test_print_text_summary_stats_avoid_generic_wrappers(
         self, args, monkeypatch, capsys
     ):
@@ -894,6 +1000,16 @@ class TestPICRun:
             {"node": 1, "contrast": 1.0, "tips": ["A", "B"]},
             {"node": 2, "contrast": -3.0, "tips": ["C", "D"]},
         ]
+
+    def test_print_json_ignores_broken_pipe(self, monkeypatch, args):
+        ic = IndependentContrasts(args)
+
+        def fail_dump(*_args, **_kwargs):
+            raise BrokenPipeError
+
+        monkeypatch.setattr(ic_module, "_json_dumps", fail_dump)
+
+        ic._print_json([1.0], [["A", "B"]], {"A": 1.0, "B": 2.0})
 
     def test_large_contrast_summary_uses_numpy_array_path(
         self, monkeypatch, args

--- a/tests/unit/services/tree/test_independent_contrasts.py
+++ b/tests/unit/services/tree/test_independent_contrasts.py
@@ -84,6 +84,46 @@ class TestIndependentContrastsInit:
 
 
 class TestPICComputation:
+    def test_tree_scans_reject_legacy_and_malformed_shapes(self, args):
+        ic = IndependentContrasts(args)
+
+        assert ic._needs_default_branch_lengths(object()) is True
+        assert ic._has_polytomies(object()) is None
+        assert ic._postorder_clades_fast(object()) is None
+        assert ic._should_use_text_summary_path(object()) is False
+
+        class MalformedRoot:
+            clades = [object()]
+            branch_length = None
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        malformed = MalformedTree()
+        assert ic._needs_default_branch_lengths(malformed) is True
+        assert ic._has_polytomies(malformed) is None
+        assert ic._postorder_clades_fast(malformed) is None
+        assert ic._should_use_text_summary_path(malformed) is False
+
+    def test_text_summary_path_detects_deep_tree(self, args):
+        ic = IndependentContrasts(args)
+
+        class Clade:
+            def __init__(self, child=None):
+                self.clades = [] if child is None else [child]
+
+        root = Clade()
+        for _ in range(66):
+            root = Clade(root)
+
+        class DeepTree:
+            pass
+
+        tree = DeepTree()
+        tree.root = root
+
+        assert ic._should_use_text_summary_path(tree) is True
+
     def test_correct_number_of_contrasts(self, args):
         """n tips should produce n-1 contrasts."""
         ic = IndependentContrasts(args)
@@ -307,6 +347,82 @@ class TestPICComputation:
 
         assert ic._compute_pic(tree, tip_traits) == expected
 
+    def test_compute_pic_generic_fallback_matches_standard_tree(
+        self, monkeypatch, args
+    ):
+        from Bio import Phylo
+        from io import StringIO
+
+        newick = "((A:1,B:2):1,(C:3,D:4):2);"
+        tip_traits = {"A": 1.0, "B": 2.0, "C": 3.0, "D": 4.0}
+        ic = IndependentContrasts(args)
+        expected = ic._compute_pic(Phylo.read(StringIO(newick), "newick"), tip_traits)
+        tree = Phylo.read(StringIO(newick), "newick")
+        monkeypatch.setattr(ic, "_compute_pic_standard_tree", lambda *_args: None)
+
+        observed = ic._compute_pic(tree, tip_traits)
+
+        np.testing.assert_allclose(observed[0], expected[0])
+        assert observed[1] == expected[1]
+
+    def test_compute_pic_generic_fallback_skips_unresolved_or_missing_nodes(
+        self, monkeypatch, args
+    ):
+        from Bio import Phylo
+        from io import StringIO
+
+        ic = IndependentContrasts(args)
+        monkeypatch.setattr(ic, "_compute_pic_standard_tree", lambda *_args: None)
+        polytomy = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        missing_tip = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+
+        assert ic._compute_pic(polytomy, {"A": 1.0}) == ([], [])
+        assert ic._compute_pic(missing_tip, {"A": 1.0}) == ([], [])
+
+    def test_text_summary_generic_fallback_matches_full_labels(
+        self, monkeypatch, args
+    ):
+        from Bio import Phylo
+        from io import StringIO
+
+        tree = Phylo.read(StringIO("((D:1,B:1):1,(C:1,A:1):1);"), "newick")
+        tip_traits = {"A": 1.0, "B": 2.0, "C": 3.0, "D": 4.0}
+        ic = IndependentContrasts(args)
+        full_contrasts, node_labels = ic._compute_pic(tree, tip_traits)
+        monkeypatch.setattr(
+            ic,
+            "_compute_pic_text_summaries_standard_tree",
+            lambda *_args: None,
+        )
+
+        contrasts, summaries = ic._compute_pic_text_summaries(tree, tip_traits)
+
+        assert contrasts == full_contrasts
+        assert summaries == [(tips[:3], len(tips)) for tips in node_labels]
+
+    def test_legacy_polytomy_resolution_fallbacks(self, args):
+        from Bio import Phylo
+        from io import StringIO
+
+        ic = IndependentContrasts(args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1,D:1);"), "newick")
+
+        class LegacyTree:
+            def find_clades(self, *call_args, **kwargs):
+                return tree.find_clades(*call_args, **kwargs)
+
+        ic._resolve_polytomies(LegacyTree())
+
+        assert len(tree.root.clades) == 2
+        assert all(len(clade.clades) <= 2 for clade in tree.find_clades())
+
+        fallback_tree = Phylo.read(
+            StringIO("(A:1,B:1,C:1,D:1);"), "newick"
+        )
+        ic._resolve_polytomies_fallback(fallback_tree)
+        assert len(fallback_tree.root.clades) == 2
+        assert all(len(clade.clades) <= 2 for clade in fallback_tree.find_clades())
+
     def test_direct_postorder_preserves_left_to_right_order(self):
         from Bio import Phylo
         from io import StringIO
@@ -334,6 +450,12 @@ class TestPICComputation:
         assert ic._merge_sorted_labels(["A", "B"], ["C"]) == ["A", "B", "C"]
         assert ic._merge_sorted_labels(["D"], ["A", "C"]) == ["A", "C", "D"]
 
+    def test_merge_sorted_labels_handles_empty_inputs(self, args):
+        ic = IndependentContrasts(args)
+
+        assert ic._merge_sorted_labels([], ["A", "B"]) == ["A", "B"]
+        assert ic._merge_sorted_labels(["A", "B"], []) == ["A", "B"]
+
     def test_limited_label_merge_preserves_sorted_preview_and_count(self, args):
         ic = IndependentContrasts(args)
 
@@ -351,6 +473,32 @@ class TestPICComputation:
             12,
             3,
         ) == (["A", "B", "C"], 32)
+
+    @pytest.mark.parametrize(
+        ("left", "right", "limit", "expected"),
+        [
+            (["A"], ["B"], 0, []),
+            ([], ["A", "B"], 1, ["A"]),
+            (["A", "B"], [], 1, ["A"]),
+            (["A", "B"], ["C", "D"], 3, ["A", "B", "C"]),
+            (["C", "D"], ["A", "B"], 3, ["A", "B", "C"]),
+        ],
+    )
+    def test_limited_label_merge_boundary_cases(
+        self, args, left, right, limit, expected
+    ):
+        ic = IndependentContrasts(args)
+
+        preview, count = ic._merge_limited_sorted_labels(
+            left,
+            len(left),
+            right,
+            len(right),
+            limit,
+        )
+
+        assert preview == expected
+        assert count == len(left) + len(right)
 
     def test_compute_pic_text_summaries_match_full_label_output(self):
         from Bio import Phylo

--- a/tests/unit/services/tree/test_internal_branch_stats.py
+++ b/tests/unit/services/tree/test_internal_branch_stats.py
@@ -126,6 +126,67 @@ class TestInternalBranchStats(object):
         assert lengths == lengths_with_names
         assert lengths_and_names == []
 
+    @pytest.mark.parametrize("include_names", [False, True])
+    def test_get_internal_branch_lengths_generic_tree_fallback(
+        self, monkeypatch, args, include_names
+    ):
+        tree = Phylo.read(
+            StringIO("((A:1,B:2):3,(C:4,D:5));"),
+            "newick",
+        )
+        monkeypatch.setattr(
+            InternalBranchStats,
+            "_get_internal_branch_lengths_direct",
+            lambda *_args, **_kwargs: None,
+        )
+
+        lengths, rows = InternalBranchStats(args).get_internal_branch_lengths(
+            tree,
+            include_names=include_names,
+        )
+
+        assert lengths == [3.0]
+        if include_names:
+            assert rows == [(3.0, ["A", "B"])]
+        else:
+            assert rows == []
+
+    def test_direct_branch_helpers_signal_nonstandard_tree_fallback(self, args):
+        class MissingRoot:
+            pass
+
+        class MissingChildClades:
+            root = type("Root", (), {"clades": [object()]})()
+
+        assert (
+            InternalBranchStats._get_internal_branch_lengths_direct(MissingRoot())
+            is None
+        )
+        assert (
+            InternalBranchStats._get_internal_branch_lengths_array_direct(MissingRoot())
+            is None
+        )
+        assert (
+            InternalBranchStats._get_internal_branch_lengths_direct(
+                MissingChildClades(),
+                include_names=False,
+            )
+            is None
+        )
+        assert (
+            InternalBranchStats._get_internal_branch_lengths_direct(
+                MissingChildClades(),
+                include_names=True,
+            )
+            is None
+        )
+        assert (
+            InternalBranchStats._get_internal_branch_lengths_array_direct(
+                MissingChildClades()
+            )
+            is None
+        )
+
     def test_get_internal_branch_lengths_uses_direct_traversal(self, monkeypatch, args):
         t = InternalBranchStats(args)
         tree = Phylo.read(StringIO("((A:1,B:2):3,(C:4,D:5):6):7;"), "newick")
@@ -272,6 +333,18 @@ class TestInternalBranchStats(object):
         out, _ = capsys.readouterr()
         assert "requires a phylogeny with branch lengths" in out
 
+    def test_calculate_nonverbose_without_lengths_exits(self, args, capsys):
+        tree = Phylo.read(StringIO("(A,B,C);"), "newick")
+
+        with pytest.raises(SystemExit) as exc_info:
+            InternalBranchStats(args).calculate_internal_branch_stats(
+                tree,
+                include_names=False,
+            )
+
+        assert exc_info.value.code == 2
+        assert "requires a phylogeny with branch lengths" in capsys.readouterr().out
+
     def test_calculate_internal_branch_stats_nonverbose_uses_array_path(
         self, mocker, args
     ):
@@ -349,6 +422,56 @@ class TestInternalBranchStats(object):
         )
 
         assert result is None
+
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            pytest.param("(", id="missing-child-and-close"),
+            pytest.param("(A", id="missing-close"),
+            pytest.param("(A B);", id="invalid-child-separator"),
+            pytest.param("();", id="missing-tip-label"),
+            pytest.param("(A:,B);", id="empty-terminal-length"),
+            pytest.param("((A,B):,C);", id="empty-internal-length"),
+            pytest.param("((A,B):invalid,C);", id="invalid-internal-length"),
+            pytest.param("(A,B)", id="missing-semicolon"),
+            pytest.param("(A,B); trailing", id="trailing-content"),
+        ],
+    )
+    def test_scan_simple_newick_internal_branches_rejects_malformed_input(
+        self, tmp_path, newick
+    ):
+        tree_file = tmp_path / "malformed.tre"
+        tree_file.write_text(newick)
+
+        assert (
+            InternalBranchStats._scan_simple_newick_internal_branches(str(tree_file))
+            is None
+        )
+
+    def test_scan_simple_newick_internal_branches_handles_deep_tree(self, tmp_path):
+        tree_file = tmp_path / "deep.tre"
+        tree_file.write_text("(" * 2_000 + "A" + ")" * 2_000 + ";")
+
+        assert (
+            InternalBranchStats._scan_simple_newick_internal_branches(str(tree_file))
+            is None
+        )
+
+    def test_run_fast_path_without_internal_lengths_exits(self, mocker, capsys):
+        service = InternalBranchStats(
+            Namespace(tree="x.tre", verbose=False, json=False)
+        )
+        mocker.patch.object(
+            service,
+            "_scan_simple_newick_internal_branches",
+            return_value=([], []),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            service.run()
+
+        assert exc_info.value.code == 2
+        assert "requires a phylogeny with branch lengths" in capsys.readouterr().out
 
     def test_run_verbose_uses_simple_newick_scan(self, mocker, capsys):
         t = InternalBranchStats(Namespace(tree="x.tre", verbose=True, json=False))

--- a/tests/unit/services/tree/test_ltt.py
+++ b/tests/unit/services/tree/test_ltt.py
@@ -122,6 +122,25 @@ class TestGammaStat:
 
         assert [tip.name for tip in tips] == ["A", "B", "C", "D", "E", "F"]
 
+    def test_terminal_clades_falls_back_to_tree_api(self):
+        tips = [object(), object(), object()]
+
+        class GenericTree:
+            def get_terminals(self):
+                return iter(tips)
+
+        assert LTT._terminal_clades(GenericTree()) == tips
+
+    def test_terminal_clades_fast_rejects_nonstandard_tree_objects(self):
+        class MissingRoot:
+            pass
+
+        class MissingChildClades:
+            root = type("Root", (), {"clades": [object()]})()
+
+        assert LTT._terminal_clades_fast(MissingRoot()) is None
+        assert LTT._terminal_clades_fast(MissingChildClades()) is None
+
     def test_balanced_tree_matches_r(self):
         """R: gammaStat(balanced_8) = -1.414214"""
         tree = Phylo.read(
@@ -284,6 +303,57 @@ class TestGammaStat:
             "D": 11.0,
         }
 
+    def test_depths_from_root_falls_back_to_tree_depths(self):
+        root = object()
+        tip = object()
+
+        class GenericTree:
+            root_reads = 0
+
+            @property
+            def root(self):
+                self.root_reads += 1
+                if self.root_reads == 1:
+                    raise AttributeError
+                return root
+
+            def depths(self):
+                return {root: 2.5, tip: 4.0}
+
+        tree = GenericTree()
+
+        assert LTT._depths_from_root(tree) == (root, {root: 2.5, tip: 4.0}, 2.5)
+
+    def test_depths_from_root_returns_none_when_fallback_is_unavailable(self):
+        class GenericTree:
+            @property
+            def root(self):
+                raise AttributeError
+
+            def depths(self):
+                raise AttributeError
+
+        assert LTT._depths_from_root(GenericTree()) is None
+
+    def test_depths_from_root_recovers_from_direct_type_error(self):
+        root = type("Root", (), {})()
+        child = type("Child", (), {"clades": [], "branch_length": "invalid"})()
+        root.clades = [child]
+
+        class GenericTree:
+            @property
+            def root(self):
+                return root
+
+            def depths(self):
+                return {root: 0.0, child: 1.0}
+
+        assert LTT._depths_from_root(GenericTree()) == (
+            root,
+            {root: 0.0, child: 1.0},
+            0.0,
+        )
+
     def test_internal_depths_from_root_handles_mixed_child_counts(self, monkeypatch):
         tree = Phylo.read(
             StringIO("(A:1,(B:1,C:1):2,(D:1,E:1,F:1):3);"),
@@ -309,6 +379,38 @@ class TestGammaStat:
 
         assert with_root == pytest.approx([0.0, 2.0, 3.0])
         assert without_root == pytest.approx([2.0, 3.0])
+
+    def test_internal_depths_rejects_missing_or_invalid_context(self):
+        assert LTT._internal_depths_from_root(object(), None, include_root=True) is None
+        assert (
+            LTT._internal_depths_from_root(
+                object(),
+                (object(), {}, 0.0),
+                include_root=True,
+            )
+            is None
+        )
+
+    def test_internal_depths_rejects_incomplete_depth_mapping(self):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        depth_data = (tree.root, {tree.root: 0.0}, 0.0)
+
+        assert (
+            LTT._internal_depths_from_root(tree, depth_data, include_root=True)
+            is None
+        )
+
+    def test_gamma_distance_fallback_matches_direct_depths(self):
+        newick = "(((A:1,B:1):1,(C:1,D:1):1):1,E:3);"
+        expected = LTT._compute_gamma(Phylo.read(StringIO(newick), "newick"))
+        tree = Phylo.read(StringIO(newick), "newick")
+        tips = list(tree.get_terminals())
+
+        observed = LTT._compute_gamma(tree, tips=tips, depth_data=None)
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2:] == expected[2:]
 
     def test_gamma_uses_provided_tree_context(self, monkeypatch):
         newick = "(((A:1,B:1):1,(C:1,D:1):1):1,E:3):0.5;"
@@ -355,6 +457,73 @@ class TestGammaStat:
         assert bt == expected_bt
         assert g == expected_g
         assert ltt_data == expected_ltt
+
+    def test_combined_gamma_and_ltt_requires_three_provided_tips(self):
+        tree = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            LTT._compute_gamma_and_ltt(
+                tree,
+                tips=list(tree.get_terminals()),
+                depth_data=None,
+            )
+
+        assert exc_info.value.messages == [
+            "Tree must have at least 3 tips for gamma statistic."
+        ]
+
+    def test_combined_gamma_and_ltt_distance_fallback_matches_direct_path(self):
+        newick = "(((A:1,B:1):1,(C:1,D:1):1):1,E:3);"
+        expected = LTT._compute_gamma_and_ltt(Phylo.read(StringIO(newick), "newick"))
+        tree = Phylo.read(StringIO(newick), "newick")
+
+        observed = LTT._compute_gamma_and_ltt(
+            tree,
+            tips=list(tree.get_terminals()),
+            depth_data=None,
+        )
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2:] == expected[2:]
+
+    def test_combined_gamma_and_ltt_uses_generic_internal_depth_fallback(
+        self, monkeypatch
+    ):
+        newick = "(((A:1,B:1):1,(C:1,D:1):1):1,E:3);"
+        expected = LTT._compute_gamma_and_ltt(Phylo.read(StringIO(newick), "newick"))
+        tree = Phylo.read(StringIO(newick), "newick")
+        tips = list(tree.get_terminals())
+        depth_data = LTT._depths_from_root(tree)
+        monkeypatch.setattr(
+            LTT,
+            "_internal_depths_from_root",
+            staticmethod(lambda *_args, **_kwargs: None),
+        )
+
+        observed = LTT._compute_gamma_and_ltt(
+            tree,
+            tips=tips,
+            depth_data=depth_data,
+        )
+
+        assert observed[0] == pytest.approx(expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2:] == expected[2:]
+
+    def test_direct_combined_helper_rejects_nonstandard_and_small_trees(self):
+        class MissingRoot:
+            pass
+
+        class MissingChildClades:
+            root = type("Root", (), {"clades": [object()]})()
+
+        assert LTT._compute_gamma_and_ltt_direct(MissingRoot()) is None
+        assert LTT._compute_gamma_and_ltt_direct(MissingChildClades()) is None
+
+        two_tip_tree = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+        with pytest.raises(PhykitUserError):
+            LTT._compute_gamma_and_ltt_direct(two_tip_tree)
 
     def test_combined_gamma_and_ltt_direct_path_avoids_setup_helpers(
         self, monkeypatch
@@ -492,6 +661,25 @@ class TestLTTPlot:
         assert os.path.exists(plot_path)
         assert os.path.getsize(plot_path) > 0
 
+    def test_plot_supports_custom_title_and_gamma_without_p_value(self, tmp_path):
+        plot_path = tmp_path / "ltt-title.png"
+        instance = LTT(
+            Namespace(
+                tree="dummy.tre",
+                title="Custom LTT",
+            )
+        )
+
+        instance._plot_ltt(
+            [(0.0, 2), (1.0, 3)],
+            str(plot_path),
+            gamma=0.5,
+            p_value=None,
+        )
+
+        assert plot_path.exists()
+        assert plot_path.stat().st_size > 0
+
 
 class TestProcessArgs:
     def test_defaults(self):
@@ -553,6 +741,7 @@ class TestRun:
         gamma_val = float(parts[0])
         p_val = float(parts[1])
         assert abs(gamma_val - (-1.4142)) < 1e-2
+        assert 0.0 <= p_val <= 1.0
 
     def test_verbose_output(self, capsys):
         args = Namespace(
@@ -590,6 +779,12 @@ class TestRun:
             "  0.000000\t2\n"
             "  0.500000\t3"
         )
+
+    def test_output_text_handles_broken_pipe(self, monkeypatch):
+        svc = LTT(Namespace(tree=BALANCED_TREE, verbose=False))
+        monkeypatch.setattr("builtins.print", Mock(side_effect=BrokenPipeError))
+
+        svc._output_text(0.5, 0.25, [], [], [])
 
     def test_json_output(self, capsys):
         args = Namespace(

--- a/tests/unit/services/tree/test_ou_shift_detection.py
+++ b/tests/unit/services/tree/test_ou_shift_detection.py
@@ -1201,6 +1201,35 @@ class TestNumericalFallbacks:
 
 
 class TestEndToEnd:
+    @staticmethod
+    def _stub_run_setup(svc, mocker, edges):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        traits = {"A": 1.0, "B": 2.0, "C": 3.0}
+        lineage = {name: [(0, 1.0, 0.0, 1.0)] for name in traits}
+        mocker.patch.object(svc, "read_tree_file_unmodified", return_value=tree)
+        mocker.patch.object(svc, "validate_tree")
+        mocker.patch.object(
+            svc, "get_tip_names_from_tree", return_value=list(traits)
+        )
+        mocker.patch.object(svc, "_parse_trait_file", return_value=traits)
+        mocker.patch.object(svc, "_build_parent_map", return_value={})
+        mocker.patch.object(
+            svc, "_build_lineage_info_no_regime", return_value=lineage
+        )
+        mocker.patch.object(svc, "_enumerate_edges", return_value=edges)
+        mocker.patch.object(
+            svc,
+            "_precompute_shared_path_lengths",
+            return_value=(np.eye(3), np.ones(3)),
+        )
+        build_result = mocker.patch.object(
+            svc,
+            "_build_final_result",
+            side_effect=lambda best, _tree: {"best": best},
+        )
+        mocker.patch.object(svc, "_output")
+        return build_result
+
     def test_pipeline_runs_with_setup(self, precomputed):
         """Pipeline should complete with pre-computed data."""
         svc = precomputed["svc"]
@@ -1341,6 +1370,45 @@ class TestEndToEnd:
         prune.assert_called_once_with("D")
         assert build_result.call_args.args[1] is tree_copy
 
+    def test_run_uses_empty_result_when_zero_edge_model_fails(
+        self, default_args, mocker
+    ):
+        svc = OUShiftDetection(default_args)
+        build_result = self._stub_run_setup(svc, mocker, edges=[])
+        mocker.patch.object(svc, "_fit_and_score_config", return_value=None)
+
+        svc.run()
+
+        fallback = build_result.call_args.args[0]
+        assert fallback["n_shifts"] == 0
+        assert fallback["log_likelihood"] == float("-inf")
+
+    def test_run_uses_empty_result_when_lasso_and_null_models_fail(
+        self, default_args, mocker
+    ):
+        svc = OUShiftDetection(default_args)
+        build_result = self._stub_run_setup(svc, mocker, edges=[(1, object())])
+        mocker.patch.object(svc, "_lasso_pass_with_selection", return_value=None)
+        mocker.patch.object(svc, "_fit_and_score_config", return_value=None)
+
+        svc.run()
+
+        assert build_result.call_args.args[0]["n_shifts"] == 0
+
+    def test_run_selects_improved_second_pass_model(self, default_args, mocker):
+        svc = OUShiftDetection(default_args)
+        build_result = self._stub_run_setup(svc, mocker, edges=[(1, object())])
+        first = {"alpha": 0.5, "pBIC": 10.0}
+        second = {"alpha": 0.75, "pBIC": 5.0}
+        lasso = mocker.patch.object(
+            svc, "_lasso_pass_with_selection", side_effect=[first, second]
+        )
+
+        svc.run()
+
+        assert lasso.call_count == 2
+        assert build_result.call_args.args[0] is second
+
 
 class TestOutput:
     def test_print_text_output_batches_detected_shifts(self, svc, mocker):
@@ -1388,6 +1456,46 @@ class TestOutput:
             "============================================================"
         )
 
+    def test_print_text_output_reports_no_shifts(self, svc, capsys):
+        result = {
+            "n_tips": 3,
+            "n_shifts": 0,
+            "criterion": "pBIC",
+            "alpha": 0.5,
+            "sigma2": 1.0,
+            "theta_root": 2.0,
+            "log_likelihood": -3.0,
+            "pBIC": 10.0,
+            "BIC": 11.0,
+            "AICc": 12.0,
+            "shifts": [],
+        }
+
+        svc._print_text_output(result)
+
+        assert "No shifts detected" in capsys.readouterr().out
+
+    def test_print_text_output_allows_closed_pipe(self, svc, monkeypatch):
+        result = {
+            "n_tips": 3,
+            "n_shifts": 0,
+            "criterion": "pBIC",
+            "alpha": 0.5,
+            "sigma2": 1.0,
+            "theta_root": 2.0,
+            "log_likelihood": -3.0,
+            "pBIC": 10.0,
+            "BIC": 11.0,
+            "AICc": 12.0,
+            "shifts": [],
+        }
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BrokenPipeError),
+        )
+
+        svc._print_text_output(result)
+
 
 class TestDescribeEdge:
     def test_terminal(self, precomputed):
@@ -1423,6 +1531,18 @@ class TestDescribeEdge:
 
         desc = svc._describe_edge(tree.root, tree)
         assert desc.startswith("stem of")
+
+    def test_falls_back_to_biopython_terminal_traversal(self, svc, monkeypatch):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        monkeypatch.setattr(
+            ou_shift_detection_module.Tree,
+            "calculate_terminal_names_fast",
+            staticmethod(lambda _clade: None),
+        )
+
+        description = svc._describe_edge(tree.root.clades[0], tree)
+
+        assert description == "stem of (A, B)"
 
 
 class TestProcessArgs:
@@ -1533,3 +1653,129 @@ class TestTraitParsing:
             "Non-numeric trait value 'bad' for taxon 'bear' on line 2."
             in exc_info.value.messages
         )
+
+    def test_missing_trait_file_error(self, tmp_path, default_args):
+        missing = tmp_path / "missing_traits.tsv"
+        svc = OUShiftDetection(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trait_file(str(missing), ["A", "B", "C"])
+
+        assert exc_info.value.code == 2
+        assert str(missing) in exc_info.value.messages[0]
+
+    def test_unordered_complete_trait_file_is_accepted(self, tmp_path, default_args):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("C\t3.0\nA\t1.0\nB\t2.0\n")
+        svc = OUShiftDetection(default_args)
+
+        traits = svc._parse_trait_file(str(trait_file), ["A", "B", "C"])
+
+        assert traits == {"C": 3.0, "A": 1.0, "B": 2.0}
+
+    def test_partial_overlap_warns_and_filters_traits(
+        self, tmp_path, default_args, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nC\t3.0\nE\t5.0\n")
+        svc = OUShiftDetection(default_args)
+
+        traits = svc._parse_trait_file(
+            str(trait_file), ["A", "B", "C", "D"]
+        )
+
+        stderr = capsys.readouterr().err
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        assert "1 taxa in tree but not in trait file: D" in stderr
+        assert "1 taxa in trait file but not in tree: E" in stderr
+
+    def test_fewer_than_three_shared_taxa_is_rejected(
+        self, tmp_path, default_args
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nD\t4.0\n")
+        svc = OUShiftDetection(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trait_file(str(trait_file), ["A", "B", "C"])
+
+        assert "Only 2 shared taxa" in exc_info.value.messages[0]
+
+
+class TestModelFailureHandling:
+    def test_lasso_pass_skips_unfittable_candidate(self, precomputed, monkeypatch):
+        svc = precomputed["svc"]
+        null = {"pBIC": 10.0, "n_shifts": 0}
+        monkeypatch.setattr(
+            svc,
+            "_build_shift_weight_matrix",
+            lambda *_args: np.ones((svc._n, len(svc._edges) + 1)),
+        )
+        monkeypatch.setattr(svc, "_build_ou_vcv_fast", lambda *_args: np.eye(svc._n))
+        monkeypatch.setattr(
+            svc,
+            "_transform_to_independent",
+            lambda x, W, _V: (W, x),
+        )
+        monkeypatch.setattr(svc, "_extract_lasso_configs", lambda *_args: [[0]])
+        monkeypatch.setattr(
+            svc, "_fit_and_score_config", lambda config: null if not config else None
+        )
+
+        assert svc._lasso_pass_with_selection(0.5, 1) is null
+
+    def test_shift_model_rejects_invalid_final_fit(self, precomputed, monkeypatch):
+        svc = precomputed["svc"]
+        monkeypatch.setattr(svc, "_optimize_alpha", lambda *_args: 0.5)
+        monkeypatch.setattr(
+            svc,
+            "_gls_profile_likelihood",
+            lambda *_args: (np.zeros(2), 0.0, float("-inf")),
+        )
+
+        assert svc._fit_and_score_config([0]) is None
+
+    def test_shift_model_rejects_unavailable_pbic(self, precomputed, monkeypatch):
+        svc = precomputed["svc"]
+        monkeypatch.setattr(svc, "_optimize_alpha", lambda *_args: 0.5)
+        monkeypatch.setattr(
+            svc,
+            "_gls_profile_likelihood",
+            lambda *_args: (np.array([1.0, 0.5]), 1.0, -2.0),
+        )
+        monkeypatch.setattr(svc, "_compute_pbic_from_vcv", lambda *_args: None)
+
+        assert svc._fit_and_score_config([0]) is None
+
+    @pytest.mark.parametrize("pbic_available", [False, True])
+    def test_null_model_rejects_invalid_fit_or_pbic(
+        self, precomputed, monkeypatch, pbic_available
+    ):
+        svc = precomputed["svc"]
+        monkeypatch.setattr(svc, "_fit_ou1_for_alpha", lambda: 0.5)
+        if pbic_available:
+            monkeypatch.setattr(
+                svc,
+                "_gls_profile_likelihood",
+                lambda *_args: (np.array([1.0]), 0.0, float("-inf")),
+            )
+        else:
+            monkeypatch.setattr(
+                svc,
+                "_gls_profile_likelihood",
+                lambda *_args: (np.array([1.0]), 1.0, -2.0),
+            )
+            monkeypatch.setattr(svc, "_compute_pbic_from_vcv", lambda *_args: None)
+
+        assert svc._fit_null_model() is None
+
+    def test_backward_elimination_keeps_model_when_reduced_fit_fails(
+        self, svc, monkeypatch
+    ):
+        fitted = {"shift_edge_indices": [0], "pBIC": 10.0}
+        monkeypatch.setattr(svc, "_fit_and_score_config", lambda _config: None)
+
+        assert svc._backward_eliminate_single_pass(fitted) is fitted
+
+    def test_cholesky_inverse_path_returns_matrix(self, svc):
+        np.testing.assert_allclose(svc._invert_vcv(np.eye(2)), np.eye(2))

--- a/tests/unit/services/tree/test_ou_shift_detection.py
+++ b/tests/unit/services/tree/test_ou_shift_detection.py
@@ -88,6 +88,14 @@ def test_lazy_pickle_caches_resolved_copy_helpers(monkeypatch):
     assert lazy_pickle.__dict__["HIGHEST_PROTOCOL"] == stdlib_pickle.HIGHEST_PROTOCOL
 
 
+def test_lazy_pickle_loads_initializes_matching_dumps_helper():
+    lazy_pickle = ou_shift_detection_module._LazyPickle()
+    payload = stdlib_pickle.dumps({"tree": "value"})
+
+    assert lazy_pickle.loads(payload) == {"tree": "value"}
+    assert lazy_pickle.dumps is stdlib_pickle.dumps
+
+
 def test_module_import_does_not_import_heavy_optional_packages(monkeypatch):
     module_name = "phykit.services.tree.ou_shift_detection"
     previous = sys.modules.pop(module_name, None)
@@ -810,6 +818,16 @@ class TestTransformToIndependent:
         transformed_V = L_inv @ V @ L_inv.T
         np.testing.assert_allclose(transformed_V, np.eye(len(x)), atol=1e-10)
 
+    def test_regularizes_positive_semidefinite_covariance(self, svc):
+        x = np.array([1.0, 2.0])
+        W = np.ones((2, 1))
+        V = np.ones((2, 2))
+
+        X_star, y_star = svc._transform_to_independent(x, W, V)
+
+        assert np.all(np.isfinite(X_star))
+        assert np.all(np.isfinite(y_star))
+
 
 class TestGLSProfileLikelihood:
     def test_cholesky_matches_inverse(self, precomputed):
@@ -857,6 +875,85 @@ class TestGLSProfileLikelihood:
         np.testing.assert_allclose(theta_fast, theta_inv)
         np.testing.assert_allclose(sig2_fast, sig2_inv)
         np.testing.assert_allclose(ll_fast, ll_inv)
+
+    def test_profile_likelihood_falls_back_to_inverse(self, svc, monkeypatch):
+        expected = (np.array([1.0]), 0.5, -2.0)
+        monkeypatch.setattr(
+            svc,
+            "_gls_profile_likelihood_cholesky",
+            lambda *_args: (_ for _ in ()).throw(ValueError("not positive definite")),
+        )
+        monkeypatch.setattr(
+            svc, "_gls_profile_likelihood_inverse", lambda *_args: expected
+        )
+
+        observed = svc._gls_profile_likelihood(
+            np.array([1.0]), np.ones((1, 1)), np.eye(1)
+        )
+
+        assert observed is expected
+
+    def test_cholesky_profile_uses_lstsq_for_collinear_predictors(self, svc):
+        x = np.array([0.0, 1.0, 4.0])
+        W = np.ones((3, 2))
+
+        theta, sigma2, log_likelihood = svc._gls_profile_likelihood_cholesky(
+            x, W, np.eye(3)
+        )
+
+        assert theta.shape == (2,)
+        assert sigma2 > 0
+        assert np.isfinite(log_likelihood)
+
+    def test_profile_likelihood_rejects_nonpositive_residual_variance(self, svc):
+        x = np.ones(3)
+        W = np.ones((3, 1))
+
+        _, sigma2_cholesky, ll_cholesky = svc._gls_profile_likelihood_cholesky(
+            x, W, np.eye(3)
+        )
+        _, sigma2_inverse, ll_inverse = svc._gls_profile_likelihood_inverse(
+            x, W, np.eye(3)
+        )
+
+        assert sigma2_cholesky <= 0
+        assert ll_cholesky == float("-inf")
+        assert sigma2_inverse <= 0
+        assert ll_inverse == float("-inf")
+
+    def test_inverse_profile_rejects_indefinite_covariance(self, svc):
+        x = np.array([0.0, 1.0])
+        W = np.zeros((2, 1))
+        V = np.diag([-1.0, 1.0])
+
+        _, sigma2, log_likelihood = svc._gls_profile_likelihood_inverse(x, W, V)
+
+        assert sigma2 > 0
+        assert log_likelihood == float("-inf")
+
+    def test_covariance_inverse_uses_fallbacks(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            ou_shift_detection_module,
+            "cho_factor",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("factor")),
+        )
+
+        np.testing.assert_allclose(svc._invert_vcv(np.eye(2)), np.eye(2))
+
+        monkeypatch.setattr(
+            np.linalg,
+            "inv",
+            lambda *_args: (_ for _ in ()).throw(np.linalg.LinAlgError("inverse")),
+        )
+        assert svc._invert_vcv(np.eye(2)) is None
+
+    def test_theta_hat_uses_lstsq_for_singular_information(self, svc):
+        x = np.array([1.0, 2.0, 3.0])
+        W = np.ones((3, 2))
+
+        theta = svc._gls_theta_hat(x, W, np.eye(3))
+
+        np.testing.assert_allclose(W @ theta, np.full(3, 2.0))
 
 
 class TestFitOU1ForAlpha:
@@ -951,6 +1048,156 @@ class TestBuildOUVCVFast:
         svc = precomputed["svc"]
         V_bm = svc._build_ou_vcv_fast(1e-12)
         np.testing.assert_allclose(V_bm, svc._S, atol=1e-6)
+
+    def test_slow_path_bm_limit(self, precomputed):
+        svc = precomputed["svc"]
+
+        observed = svc._build_ou_vcv_single_alpha_no_regime(
+            precomputed["ordered_names"],
+            precomputed["lineage_info"],
+            alpha=1e-12,
+            sigma2=2.0,
+        )
+
+        np.testing.assert_allclose(observed, 2.0 * svc._S)
+
+
+class TestNumericalFallbacks:
+    def test_lineage_row_cache_rebuilds_from_paths(self, precomputed):
+        svc = precomputed["svc"]
+        svc._lineage_rows_by_clade_id = None
+
+        rows_by_clade = svc._get_lineage_rows_by_clade_id()
+
+        assert rows_by_clade is svc._lineage_rows_by_clade_id
+        assert rows_by_clade
+        assert all(rows.dtype == np.intp for rows in rows_by_clade.values())
+
+    def test_zero_length_bm_shift_keeps_background_weight(self, svc):
+        lineage = {"A": [(101, 0.0, 0.0, 0.0)]}
+
+        weights = svc._build_shift_weight_matrix(
+            ["A"], lineage, [(101, object())], alpha=0.0, tree_height=0.0
+        )
+
+        np.testing.assert_allclose(weights, [[1.0, 0.0]])
+
+    def test_alpha_fit_slow_path_penalizes_invalid_likelihood(self, svc, monkeypatch):
+        svc._x = np.array([1.0, 2.0, 3.0])
+        svc._tree_height = 1.0
+        monkeypatch.setattr(
+            svc,
+            "_build_ou_vcv_single_alpha_no_regime",
+            lambda *_args: np.eye(3),
+        )
+        monkeypatch.setattr(
+            svc,
+            "_gls_profile_likelihood",
+            lambda *_args: (np.array([0.0]), 0.0, float("-inf")),
+        )
+
+        def exercise_objective(objective, _bounds):
+            assert objective(0.5) == 1e20
+            return 0.5, -1e20
+
+        monkeypatch.setattr(svc, "_optimize_parameter", exercise_objective)
+
+        assert svc._fit_ou1_for_alpha(
+            ordered_names=["A", "B", "C"],
+            lineage_info={"A": [], "B": [], "C": []},
+            tree_height=1.0,
+        ) == pytest.approx(0.5)
+
+    @pytest.mark.parametrize("exception", [ValueError("bad"), RuntimeError("bad")])
+    def test_alpha_optimizer_returns_midpoint_on_failure(
+        self, svc, monkeypatch, exception
+    ):
+        monkeypatch.setattr(
+            ou_shift_detection_module,
+            "minimize_scalar",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(exception),
+        )
+
+        assert svc._optimize_alpha(lambda _alpha: 0.0, (2.0, 6.0)) == 4.0
+
+    def test_multibracket_optimizer_tolerates_failed_brackets(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            ou_shift_detection_module,
+            "minimize_scalar",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")),
+        )
+
+        parameter, score = svc._optimize_parameter(
+            lambda _alpha: 0.0, (2.0, 6.0), niter=2
+        )
+
+        assert parameter == 4.0
+        assert score == float("-inf")
+
+    def test_multibracket_optimizer_ignores_empty_brackets(self, svc):
+        parameter, score = svc._optimize_parameter(
+            lambda _alpha: 0.0, (2.0, 2.0), niter=2
+        )
+
+        assert parameter == 2.0
+        assert score == float("-inf")
+
+    def test_lasso_config_extraction_handles_degenerate_designs(
+        self, svc, monkeypatch
+    ):
+        svc._n = 3
+        y = np.arange(3.0)
+
+        assert svc._extract_lasso_configs(np.ones((3, 1)), y, max_shifts=2) == []
+        assert svc._extract_lasso_configs(np.ones((3, 2)), y, max_shifts=0) == []
+
+        monkeypatch.setattr(
+            ou_shift_detection_module,
+            "_lars_path",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("lasso")),
+        )
+        assert svc._extract_lasso_configs(np.eye(3), y, max_shifts=2) == []
+
+    def test_pbic_vcv_uses_inverse_fallback(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            ou_shift_detection_module,
+            "cho_factor",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("factor")),
+        )
+        svc._n_edges = 5
+        x = np.array([1.0, 2.0, 4.0])
+        W = np.ones((3, 1))
+
+        observed = svc._compute_pbic_from_vcv(
+            3, -2.0, 0, W, np.eye(3), 1.0, x
+        )
+
+        assert np.isfinite(observed)
+
+        monkeypatch.setattr(
+            np.linalg,
+            "inv",
+            lambda *_args: (_ for _ in ()).throw(np.linalg.LinAlgError("inverse")),
+        )
+        assert svc._compute_pbic_from_vcv(
+            3, -2.0, 0, W, np.eye(3), 1.0, x
+        ) is None
+
+    def test_pbic_rejects_degenerate_information(self, svc):
+        svc._n_edges = 5
+
+        assert svc._compute_pbic_from_info(
+            3, -2.0, 0, np.eye(1), 1.0, np.ones(3)
+        ) == float("inf")
+        assert svc._compute_pbic_from_info(
+            2, -2.0, 1, np.eye(2), 1.0, np.array([1.0, 2.0])
+        ) == float("inf")
+        assert svc._compute_pbic_from_info(
+            3, -2.0, 0, np.eye(1), 0.0, np.array([1.0, 2.0, 4.0])
+        ) == float("inf")
+        assert svc._compute_pbic_from_info(
+            3, -2.0, 0, -np.eye(1), 1.0, np.array([1.0, 2.0, 4.0])
+        ) == float("inf")
 
 
 class TestEndToEnd:

--- a/tests/unit/services/tree/test_ouwie.py
+++ b/tests/unit/services/tree/test_ouwie.py
@@ -445,6 +445,47 @@ class TestProcessArgs:
         assert ordered_names == ["B", "C", "D"]
         assert regime_names == ["r1", "r2"]
 
+    @pytest.mark.parametrize(
+        ("traits", "regimes"),
+        [
+            ({"A": 1.0, "B": 2.0}, {"A": "r1", "B": "r2"}),
+            (
+                {"A": 1.0, "B": 2.0, "trait_only": 3.0},
+                {"A": "r1", "B": "r2", "regime_only": "r3"},
+            ),
+        ],
+    )
+    def test_prepare_shared_trait_regime_data_requires_three_taxa(
+        self, traits, regimes
+    ):
+        with pytest.raises(PhykitUserError) as excinfo:
+            OUwie._prepare_shared_trait_regime_data(
+                ["A", "B", "C"], traits, regimes
+            )
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa among tree, trait, and regime files.",
+            "At least 3 shared taxa are required.",
+        ]
+
+    def test_prepare_shared_trait_regime_data_reuses_reordered_complete_mappings(
+        self,
+    ):
+        traits = {"A": 1.0, "B": 2.0, "C": 3.0}
+        regimes = {"C": "r1", "B": "r2", "A": "r1"}
+
+        shared_traits, shared_regimes, tips_to_prune, ordered_names, regime_names = (
+            OUwie._prepare_shared_trait_regime_data(
+                ["A", "B", "C", "D"], traits, regimes
+            )
+        )
+
+        assert shared_traits is traits
+        assert shared_regimes is regimes
+        assert tips_to_prune == ["D"]
+        assert ordered_names == ["A", "B", "C"]
+        assert regime_names == ["r1", "r2"]
+
 
 class TestTraitAndRegimeParsing:
     def test_trait_file_skips_comments_and_blanks(self, tmp_path, default_args):
@@ -528,6 +569,46 @@ class TestTraitAndRegimeParsing:
             in exc_info.value.messages
         )
 
+    def test_trait_file_not_found(self, tmp_path, default_args):
+        svc = OUwie(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_trait_file(
+                str(tmp_path / "missing.tsv"), ["A", "B", "C"]
+            )
+
+        assert "corresponds to no such file or directory" in excinfo.value.messages[0]
+
+    def test_trait_file_reports_taxon_mismatches(
+        self, tmp_path, default_args, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1\nB\t2\nC\t3\nX\t4\n")
+        svc = OUwie(default_args)
+
+        traits = svc._parse_trait_file(
+            str(trait_file), ["A", "B", "C", "D"]
+        )
+
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: D",
+            "Warning: 1 taxa in trait file but not in tree: X",
+        ]
+
+    def test_trait_file_requires_three_shared_taxa(self, tmp_path, default_args):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1\nB\t2\nX\t3\n")
+        svc = OUwie(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_trait_file(str(trait_file), ["A", "B", "C"])
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
+
     def test_all_shared_regime_file_emits_no_warnings(
         self, tmp_path, default_args, capsys
     ):
@@ -578,6 +659,48 @@ class TestTraitAndRegimeParsing:
             "Line 5 in regime file has 3 columns; expected 2."
             in exc_info.value.messages
         )
+
+    def test_regime_file_not_found(self, tmp_path, default_args):
+        svc = OUwie(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_regime_file(
+                str(tmp_path / "missing.tsv"), ["A", "B", "C"]
+            )
+
+        assert "corresponds to no such file or directory" in excinfo.value.messages[0]
+
+    def test_regime_file_reports_taxon_mismatches(
+        self, tmp_path, default_args, capsys
+    ):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text("A\tr1\nB\tr1\nC\tr2\nX\tr2\n")
+        svc = OUwie(default_args)
+
+        regimes = svc._parse_regime_file(
+            str(regime_file), ["A", "B", "C", "D"]
+        )
+
+        assert regimes == {"A": "r1", "B": "r1", "C": "r2"}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in regime file: D",
+            "Warning: 1 taxa in regime file but not in tree: X",
+        ]
+
+    def test_regime_file_requires_three_shared_taxa(
+        self, tmp_path, default_args
+    ):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text("A\tr1\nB\tr1\nX\tr2\n")
+        svc = OUwie(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._parse_regime_file(str(regime_file), ["A", "B", "C"])
+
+        assert excinfo.value.messages == [
+            "Only 2 shared taxa between tree and regime file.",
+            "At least 3 shared taxa are required.",
+        ]
 
 
 # ── TestWeightMatrix ─────────────────────────────────────────────────
@@ -763,6 +886,29 @@ class TestRegimeAssignment:
         assert parent_map[id(trifurcation.clades[2])] is trifurcation
         assert id(tree.root) not in parent_map
 
+    def test_parent_map_supports_legacy_tree_interface(self, svc):
+        tree = NewickTree(
+            root=Clade(
+                clades=[
+                    Clade(
+                        clades=[Clade(name="A"), Clade(name="B")],
+                    ),
+                    Clade(name="C"),
+                ]
+            )
+        )
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        parent_map = svc._build_parent_map(LegacyTree())
+
+        internal, terminal = tree.root.clades
+        assert parent_map[id(internal)] is tree.root
+        assert parent_map[id(terminal)] is tree.root
+        assert all(parent_map[id(child)] is internal for child in internal.clades)
+
     def test_combined_branch_and_root_regime_uses_direct_traversal(
         self, svc, monkeypatch
     ):
@@ -873,6 +1019,110 @@ class TestRegimeAssignment:
         assert root_regime == "alpha"
         assert branch_regimes[id(left)] == "beta"
         assert branch_regimes[id(right)] == "alpha"
+
+    def test_regime_assignment_falls_back_when_reversed_is_unavailable(
+        self, svc, monkeypatch
+    ):
+        tree = NewickTree(
+            root=Clade(
+                clades=[
+                    Clade(name="A", branch_length=1.0),
+                    Clade(name="B", branch_length=1.0),
+                    Clade(name="C", branch_length=1.0),
+                ]
+            )
+        )
+        parent_map = svc._build_parent_map(tree)
+        expected = svc._assign_branch_regimes_and_root(
+            tree, {"A": "r1", "B": "r2", "C": "r1"}, parent_map
+        )
+        original_reversed = reversed
+        call_count = 0
+
+        def fail_first_reversed(values):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AttributeError("reversed traversal unavailable")
+            return original_reversed(values)
+
+        monkeypatch.setattr(builtins, "reversed", fail_first_reversed)
+
+        observed = svc._assign_branch_regimes_and_root(
+            tree, {"A": "r1", "B": "r2", "C": "r1"}, parent_map
+        )
+
+        assert observed == expected
+
+    @pytest.mark.parametrize(
+        ("tip_regimes", "expected_root"),
+        [({"A": "r1"}, "r1"), ({"B": "r2"}, "r2"), ({}, "unknown")],
+    )
+    def test_regime_assignment_handles_missing_tip_annotations(
+        self, svc, tip_regimes, expected_root
+    ):
+        tree = NewickTree(
+            root=Clade(
+                clades=[
+                    Clade(
+                        clades=[
+                            Clade(name="A", branch_length=1.0),
+                            Clade(name="B", branch_length=1.0),
+                        ],
+                        branch_length=1.0,
+                    ),
+                    Clade(name="C", branch_length=1.0),
+                ]
+            )
+        )
+        parent_map = svc._build_parent_map(tree)
+
+        branch_regimes, root_regime = svc._assign_branch_regimes_and_root(
+            tree, tip_regimes, parent_map
+        )
+
+        assert root_regime == expected_root
+        assert set(branch_regimes.values()) == {expected_root}
+
+    def test_regime_assignment_uses_node_state_without_parent_map(self, svc):
+        tree = NewickTree(
+            root=Clade(
+                clades=[
+                    Clade(name="A", branch_length=1.0),
+                    Clade(name="B", branch_length=1.0),
+                    Clade(name="C", branch_length=1.0),
+                ]
+            )
+        )
+
+        branch_regimes, root_regime = svc._assign_branch_regimes_and_root(
+            tree, {"A": "r1", "B": "r2", "C": "r1"}, {}
+        )
+
+        assert root_regime == "r1"
+        assert branch_regimes[id(tree.root.clades[0])] == "r1"
+        assert branch_regimes[id(tree.root.clades[1])] == "r2"
+
+
+class TestRunValidation:
+    def test_run_requires_two_distinct_regimes(
+        self, tmp_path, default_args
+    ):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text(
+            "raccoon\tA\nbear\tA\nsea_lion\tA\nseal\tA\n"
+            "monkey\tA\ncat\tA\nweasel\tA\ndog\tA\n"
+        )
+        default_args.regime_data = str(regime_file)
+        default_args.models = "BM1"
+        svc = OUwie(default_args)
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc.run()
+
+        assert excinfo.value.messages == [
+            "At least 2 distinct regimes are required for OUwie models."
+        ]
 
 
 class TestVCV:

--- a/tests/unit/services/tree/test_ouwie.py
+++ b/tests/unit/services/tree/test_ouwie.py
@@ -1331,6 +1331,42 @@ class TestVCV:
 
         assert tip_map == {"A": terminals[0], "C": terminals[2]}
 
+    def test_terminal_map_falls_back_after_direct_traversal_fails(self, svc):
+        terminals = [Clade(name="A"), Clade(name="B")]
+
+        class FlakyRoot:
+            accesses = 0
+
+            @property
+            def clades(self):
+                self.accesses += 1
+                if self.accesses > 1:
+                    raise AttributeError("direct traversal unavailable")
+                return terminals
+
+        class FlakyTree:
+            root = FlakyRoot()
+
+            def get_terminals(self):
+                return terminals
+
+        tip_map = svc._terminal_map_for_ordered_names(FlakyTree(), ["B"])
+
+        assert tip_map == {"B": terminals[1]}
+
+    def test_path_vcv_ignores_unselected_branch_regimes(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            svc,
+            "_build_root_to_tip_paths",
+            lambda *_args: {"A": [("tip", 1.0)]},
+        )
+
+        observed = svc._build_per_regime_vcv(
+            object(), ["A"], ["r1"], {"tip": "not-selected"}, {}
+        )
+
+        np.testing.assert_array_equal(observed["r1"], [[0.0]])
+
     def test_weight_builders_ignore_unknown_regimes_and_support_bm_limits(
         self, svc
     ):
@@ -1403,6 +1439,11 @@ class TestVCV:
         np.testing.assert_allclose(single, 2.0 * cache["shared_paths"])
         np.testing.assert_allclose(sum(per_regime.values()), cache["shared_paths"])
         np.testing.assert_allclose(multi, single)
+
+        unknown = svc._build_ou_H_matrices(
+            ["A"], {"A": [("tip", 1.0, "unknown", 0.0, 1.0)]}, ["r1"], 0.5
+        )
+        np.testing.assert_array_equal(unknown["r1"], [[0.0]])
 
     def test_single_alpha_cache_uses_shared_branch_lengths(self, svc):
         ordered_names = ["A", "B", "C"]
@@ -1899,6 +1940,23 @@ class TestNumericalFallbacks:
         assert indefinite[0] == float("-inf")
         assert indefinite[1] > 0
 
+    def test_inverse_likelihoods_reject_zero_total_precision(
+        self, svc, monkeypatch
+    ):
+        zero_precision_inverse = np.array([[1.0, -1.0], [-1.0, 1.0]])
+        monkeypatch.setattr(
+            ouwie_module.np.linalg,
+            "inv",
+            lambda _matrix: zero_precision_inverse,
+        )
+
+        assert svc._concentrated_ll_bm_inverse(
+            np.array([1.0, 2.0]), np.eye(2)
+        ) == (float("-inf"), 0.0, 0.0)
+        assert svc._bm_log_likelihood_from_vcv_inverse(
+            np.array([1.0, 2.0]), np.eye(2), np.ones(2)
+        ) == (0.0, float("-inf"))
+
     def test_bm_vcv_likelihood_falls_back_to_inverse(self, svc, monkeypatch):
         x = np.array([1.0, 2.0, 4.0])
         V = np.diag([1.0, 2.0, 3.0])
@@ -2041,6 +2099,26 @@ class TestNumericalFallbacks:
         np.testing.assert_array_equal(theta, [0.0])
         assert ll == float("-inf")
 
+    def test_inverse_ou_likelihoods_handle_inverse_failure(
+        self, svc, monkeypatch
+    ):
+        def fail_inverse(_matrix):
+            raise np.linalg.LinAlgError("singular")
+
+        monkeypatch.setattr(ouwie_module.np.linalg, "inv", fail_inverse)
+        x = np.array([1.0, 2.0])
+        W = np.ones((2, 1))
+
+        profile = svc._ou_profile_likelihood_inverse(x, W, np.eye(2))
+        gls = svc._ou_gls_log_likelihood_inverse(x, W, np.eye(2))
+        bm = svc._bm_log_likelihood_from_vcv_inverse(x, np.eye(2), np.ones(2))
+
+        np.testing.assert_array_equal(profile[0], [0.0])
+        assert profile[1:] == (0.0, float("-inf"))
+        np.testing.assert_array_equal(gls[0], [0.0])
+        assert gls[1] == float("-inf")
+        assert bm == (0.0, float("-inf"))
+
     def test_fit_model_rejects_unknown_internal_model(self, svc, precomputed):
         d = precomputed
 
@@ -2082,6 +2160,96 @@ class TestNumericalFallbacks:
             -np.inf,
         )
         assert calls == 10
+
+    def test_all_models_return_stable_results_when_optimization_fails(
+        self, precomputed, monkeypatch
+    ):
+        d = precomputed
+
+        def exercise_objective_then_fail(objective, initial, **_kwargs):
+            assert objective(initial) == 1e20
+            raise ValueError("optimizer failed")
+
+        monkeypatch.setattr(ouwie_module, "minimize", exercise_objective_then_fail)
+        monkeypatch.setattr(
+            d["svc"],
+            "_bm_log_likelihood_from_vcv",
+            lambda *_args: (0.0, float("-inf")),
+        )
+        monkeypatch.setattr(
+            d["svc"],
+            "_ou_profile_likelihood",
+            lambda _x, W, _V: (
+                np.zeros(W.shape[1]),
+                0.0,
+                float("-inf"),
+            ),
+        )
+        monkeypatch.setattr(
+            d["svc"],
+            "_ou_gls_log_likelihood",
+            lambda _x, W, _V: (np.zeros(W.shape[1]), float("-inf")),
+        )
+
+        def exercise_scalar_objective(objective, _bounds, niter=10):
+            assert niter == 10
+            assert objective(0.1) == 1e20
+            return 0.1, -np.inf
+
+        monkeypatch.setattr(
+            d["svc"], "_optimize_parameter", exercise_scalar_objective
+        )
+
+        results = [
+            d["svc"]._fit_bms(
+                d["x"], d["per_regime_vcv"], d["regimes"]
+            ),
+            d["svc"]._fit_ou1(
+                d["x"], d["ordered_names"], d["lineage_info"], 0.0
+            ),
+            d["svc"]._fit_oum(
+                d["x"],
+                d["ordered_names"],
+                d["lineage_info"],
+                d["regimes"],
+                d["root_regime"],
+                0.0,
+            ),
+            d["svc"]._fit_oumv(
+                d["x"],
+                d["ordered_names"],
+                d["lineage_info"],
+                d["regimes"],
+                d["root_regime"],
+                0.0,
+            ),
+            d["svc"]._fit_ouma(
+                d["x"],
+                d["ordered_names"],
+                d["lineage_info"],
+                d["regimes"],
+                d["root_regime"],
+                0.0,
+            ),
+            d["svc"]._fit_oumva(
+                d["x"],
+                d["ordered_names"],
+                d["lineage_info"],
+                d["regimes"],
+                d["root_regime"],
+                0.0,
+            ),
+        ]
+
+        assert [result["model"] for result in results] == [
+            "BMS",
+            "OU1",
+            "OUM",
+            "OUMV",
+            "OUMA",
+            "OUMVA",
+        ]
+        assert all(result["log_likelihood"] == float("-inf") for result in results)
 
     def test_cholesky_bm_likelihood_uses_single_solve(
         self, precomputed, monkeypatch
@@ -2598,6 +2766,27 @@ class TestModelComparison:
         for r in results:
             assert np.isfinite(r["log_likelihood"]), f"{r['model']} LL not finite"
 
+    def test_undefined_model_comparison_values_use_stable_sentinels(self, svc):
+        results = [
+            {
+                "model": "custom",
+                "k_params": 2,
+                "log_likelihood": -1.0,
+                "params": {},
+            }
+        ]
+
+        compared = svc._compute_model_comparison(
+            results,
+            n=2,
+            regime_assignments={"A": None},
+            ordered_names=["A"],
+        )
+
+        assert compared[0]["aicc"] == float("inf")
+        assert compared[0]["aicc_weight"] == 0.0
+        assert np.isnan(compared[0]["r_squared"])
+
 
 # ── TestRun ──────────────────────────────────────────────────────────
 
@@ -2685,6 +2874,29 @@ class TestRun:
             "    aquatic: 0.0500\n"
             "    terrestrial: 0.0600"
         )
+
+    def test_print_text_output_formats_scalar_ou_parameters(self, svc, mocker):
+        printed = mocker.patch("builtins.print")
+        result = {
+            "model": "OU1",
+            "k_params": 3,
+            "log_likelihood": -2.0,
+            "aic": 10.0,
+            "aicc": 11.0,
+            "delta_aicc": 0.0,
+            "aicc_weight": 1.0,
+            "bic": 12.0,
+            "delta_bic": 0.0,
+            "r_squared": 0.5,
+            "params": {"theta": 1.5, "alpha": 0.2, "sigma2": 0.3},
+        }
+
+        svc._print_text_output([result], 8, ["r1", "r2"])
+
+        output = printed.call_args.args[0]
+        assert "Theta: 1.5000" in output
+        assert "Alpha: 0.2000" in output
+        assert "Sigma-squared: 0.3000" in output
 
     @patch("builtins.print")
     def test_json_output(self, mocked_print):

--- a/tests/unit/services/tree/test_ouwie.py
+++ b/tests/unit/services/tree/test_ouwie.py
@@ -1306,6 +1306,104 @@ class TestVCV:
         np.testing.assert_allclose(observed["r1"], [[2.0, 2.0], [2.0, 2.0]])
         np.testing.assert_allclose(observed["r2"], [[1.0, 0.0], [0.0, 3.0]])
 
+    def test_per_regime_vcv_handles_unknown_and_unrecognized_regimes(self, svc):
+        lineage_info = {
+            "A": [("A_tip", 1.0, "unknown", 0.0, 1.0)],
+            "B": [("B_tip", 2.0, "not-selected", 0.0, 2.0)],
+        }
+
+        observed = svc._build_per_regime_vcv_from_lineage_info(
+            ["A", "B"], ["r1"], lineage_info
+        )
+
+        np.testing.assert_array_equal(observed["r1"], [[1.0, 0.0], [0.0, 0.0]])
+
+    def test_terminal_map_supports_legacy_tree_interface(self, svc):
+        terminals = [Clade(name="A"), Clade(name="B"), Clade(name="C")]
+
+        class LegacyTree:
+            def get_terminals(self):
+                return terminals
+
+        tip_map = svc._terminal_map_for_ordered_names(
+            LegacyTree(), ["A", "C"]
+        )
+
+        assert tip_map == {"A": terminals[0], "C": terminals[2]}
+
+    def test_weight_builders_ignore_unknown_regimes_and_support_bm_limits(
+        self, svc
+    ):
+        ordered_names = ["A"]
+        unknown_lineage = {
+            "A": [("tip", 1.0, "unknown", 0.0, 1.0)]
+        }
+        known_lineage = {"A": [("tip", 2.0, "r1", 0.0, 2.0)]}
+
+        unknown = svc._build_weight_matrix_single_alpha(
+            ordered_names, unknown_lineage, ["r1"], 0.0, "missing"
+        )
+        bm_limit = svc._build_weight_matrix_single_alpha(
+            ordered_names, known_lineage, ["r1"], 0.0, "r1"
+        )
+        cache = svc._prepare_single_alpha_weight_cache(
+            ordered_names, unknown_lineage, ["r1"], "missing"
+        )
+
+        np.testing.assert_array_equal(unknown, [[0.0]])
+        np.testing.assert_array_equal(bm_limit, [[1.0]])
+        assert cache["rows"].size == 0
+        assert cache["root_col"] is None
+
+    def test_multi_alpha_weights_handle_sparse_lineages(self, svc):
+        lineage_info = {
+            "A": [
+                ("unknown", 1.0, "unknown", 0.0, 1.0),
+                ("known", 2.0, "r1", 1.0, 3.0),
+            ],
+            "B": [],
+        }
+
+        without_root = svc._build_weight_matrix_multi_alpha(
+            ["A", "B"], lineage_info, ["r1"], {"r1": 0.0}, "missing"
+        )
+        with_root = svc._build_weight_matrix_multi_alpha(
+            ["A", "B"], lineage_info, ["r1"], {"r1": 0.0}, "r1"
+        )
+
+        np.testing.assert_array_equal(without_root, [[2.0], [0.0]])
+        np.testing.assert_allclose(with_root, [[2.0 + np.exp(-0.01)], [1.0]])
+
+    def test_ou_covariance_builders_support_bm_limits(self, svc):
+        ordered_names = ["A", "B"]
+        lineage_info = {
+            "A": [
+                ("shared", 1.0, "r1", 0.0, 1.0),
+                ("A_tip", 1.0, "r1", 1.0, 2.0),
+            ],
+            "B": [
+                ("shared", 1.0, "r1", 0.0, 1.0),
+                ("B_tip", 2.0, "r2", 1.0, 3.0),
+            ],
+        }
+        cache = svc._prepare_single_alpha_ou_cache(ordered_names, lineage_info)
+
+        single = svc._build_ou_vcv_single_alpha_from_cache(cache, 0.0, 2.0)
+        per_regime = svc._build_ou_H_matrices(
+            ordered_names, lineage_info, ["r1", "r2"], 0.0
+        )
+        multi = svc._build_ou_vcv_multi_alpha(
+            ordered_names,
+            lineage_info,
+            ["r1", "r2"],
+            {"r1": 0.0, "r2": 0.0},
+            {"r1": 2.0, "r2": 2.0},
+        )
+
+        np.testing.assert_allclose(single, 2.0 * cache["shared_paths"])
+        np.testing.assert_allclose(sum(per_regime.values()), cache["shared_paths"])
+        np.testing.assert_allclose(multi, single)
+
     def test_single_alpha_cache_uses_shared_branch_lengths(self, svc):
         ordered_names = ["A", "B", "C"]
         lineage_info = {
@@ -1707,6 +1805,283 @@ class TestBM1:
         fast = d["svc"]._concentrated_ll_bm_cholesky(d["x"], d["vcv_total"])
         inverse = d["svc"]._concentrated_ll_bm_inverse(d["x"], d["vcv_total"])
         np.testing.assert_allclose(fast, inverse)
+
+
+class TestNumericalFallbacks:
+    def test_gls_theta_uses_least_squares_for_singular_information(self, svc):
+        x = np.array([1.0, 2.0, 3.0])
+        W = np.ones((3, 2))
+
+        theta = svc._gls_theta_hat(x, W, np.eye(3))
+
+        np.testing.assert_allclose(W @ theta, np.full(3, 2.0))
+
+    def test_ou_log_likelihood_rejects_invalid_covariances(
+        self, svc, monkeypatch
+    ):
+        x = np.array([1.0, 2.0])
+        W = np.ones((2, 1))
+        theta = np.array([1.5])
+
+        assert np.isfinite(svc._ou_log_likelihood(x, W, np.eye(2), theta))
+        assert svc._ou_log_likelihood(
+            x, W, np.diag([1.0, -1.0]), theta
+        ) == float("-inf")
+
+        def fail_inverse(_matrix):
+            raise np.linalg.LinAlgError("singular")
+
+        monkeypatch.setattr(ouwie_module.np.linalg, "inv", fail_inverse)
+        assert svc._ou_log_likelihood(x, W, np.eye(2), theta) == float("-inf")
+
+    def test_concentrated_bm_falls_back_to_inverse(
+        self, svc, monkeypatch
+    ):
+        x = np.array([1.0, 2.0, 4.0])
+        C = np.diag([1.0, 2.0, 3.0])
+        expected = svc._concentrated_ll_bm_inverse(x, C)
+
+        def fail_cholesky(_x, _C):
+            raise ValueError("not positive definite")
+
+        monkeypatch.setattr(svc, "_concentrated_ll_bm_cholesky", fail_cholesky)
+
+        np.testing.assert_allclose(svc._concentrated_ll_bm(x, C), expected)
+
+    def test_concentrated_bm_cholesky_rejects_zero_precision(
+        self, svc, monkeypatch
+    ):
+        monkeypatch.setattr(
+            ouwie_module,
+            "cho_factor",
+            lambda matrix, **_kwargs: (matrix, True),
+        )
+        monkeypatch.setattr(
+            ouwie_module,
+            "cho_solve",
+            lambda _factor, rhs, **_kwargs: np.zeros_like(rhs),
+        )
+
+        result = svc._concentrated_ll_bm_cholesky(
+            np.array([1.0, 2.0]), np.eye(2)
+        )
+
+        assert result == (float("-inf"), 0.0, 0.0)
+
+    def test_concentrated_bm_rejects_nonpositive_variance(self, svc):
+        x = np.array([2.0, 2.0, 2.0])
+
+        assert svc._concentrated_ll_bm_cholesky(x, np.eye(3)) == (
+            float("-inf"),
+            0.0,
+            2.0,
+        )
+        assert svc._concentrated_ll_bm_inverse(x, np.eye(3)) == (
+            float("-inf"),
+            0.0,
+            2.0,
+        )
+
+    def test_concentrated_bm_inverse_rejects_singular_and_indefinite_inputs(
+        self, svc, monkeypatch
+    ):
+        singular = svc._concentrated_ll_bm_inverse(
+            np.array([1.0, 2.0]), np.zeros((2, 2))
+        )
+        assert singular == (float("-inf"), 0.0, 0.0)
+
+        monkeypatch.setattr(
+            ouwie_module.np.linalg, "slogdet", lambda _matrix: (-1.0, 0.0)
+        )
+        indefinite = svc._concentrated_ll_bm_inverse(
+            np.array([1.0, 2.0]), np.eye(2)
+        )
+        assert indefinite[0] == float("-inf")
+        assert indefinite[1] > 0
+
+    def test_bm_vcv_likelihood_falls_back_to_inverse(self, svc, monkeypatch):
+        x = np.array([1.0, 2.0, 4.0])
+        V = np.diag([1.0, 2.0, 3.0])
+        ones = np.ones(3)
+        expected = svc._bm_log_likelihood_from_vcv_inverse(x, V, ones)
+
+        def fail_cholesky(_x, _V, _ones):
+            raise np.linalg.LinAlgError("not positive definite")
+
+        monkeypatch.setattr(
+            svc, "_bm_log_likelihood_from_vcv_cholesky", fail_cholesky
+        )
+
+        np.testing.assert_allclose(
+            svc._bm_log_likelihood_from_vcv(x, V, ones), expected
+        )
+
+    def test_bm_vcv_likelihood_rejects_zero_precision(
+        self, svc, monkeypatch
+    ):
+        monkeypatch.setattr(
+            ouwie_module,
+            "cho_factor",
+            lambda matrix, **_kwargs: (matrix, True),
+        )
+        monkeypatch.setattr(
+            ouwie_module,
+            "cho_solve",
+            lambda _factor, rhs, **_kwargs: np.zeros_like(rhs),
+        )
+
+        result = svc._bm_log_likelihood_from_vcv_cholesky(
+            np.array([1.0, 2.0]), np.eye(2), np.ones(2)
+        )
+
+        assert result == (0.0, float("-inf"))
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [np.diag([1.0, -1.0]), np.zeros((2, 2))],
+    )
+    def test_bm_vcv_inverse_rejects_invalid_covariances(self, svc, matrix):
+        result = svc._bm_log_likelihood_from_vcv_inverse(
+            np.array([1.0, 2.0]), matrix, np.ones(2)
+        )
+
+        assert result == (0.0, float("-inf"))
+
+    def test_ou_profile_likelihood_falls_back_to_inverse(
+        self, svc, monkeypatch
+    ):
+        x = np.array([1.0, 2.0, 4.0])
+        W = np.ones((3, 1))
+        V = np.diag([1.0, 2.0, 3.0])
+        expected = svc._ou_profile_likelihood_inverse(x, W, V)
+
+        def fail_cholesky(_x, _W, _V):
+            raise FloatingPointError("factorization failed")
+
+        monkeypatch.setattr(svc, "_ou_profile_likelihood_cholesky", fail_cholesky)
+        observed = svc._ou_profile_likelihood(x, W, V)
+
+        np.testing.assert_allclose(observed[0], expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+        assert observed[2] == pytest.approx(expected[2])
+
+    def test_ou_profile_cholesky_handles_singular_design_and_zero_variance(
+        self, svc
+    ):
+        W = np.ones((3, 2))
+        theta, sigma2, ll = svc._ou_profile_likelihood_cholesky(
+            np.array([1.0, 2.0, 3.0]), W, np.eye(3)
+        )
+        np.testing.assert_allclose(W @ theta, np.full(3, 2.0))
+        assert sigma2 > 0
+        assert np.isfinite(ll)
+
+        _, sigma2, ll = svc._ou_profile_likelihood_cholesky(
+            np.ones(3), np.ones((3, 1)), np.eye(3)
+        )
+        assert sigma2 == 0.0
+        assert ll == float("-inf")
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [np.diag([1.0, -1.0]), np.zeros((2, 2))],
+    )
+    def test_ou_profile_inverse_rejects_invalid_covariances(
+        self, svc, matrix
+    ):
+        theta, sigma2, ll = svc._ou_profile_likelihood_inverse(
+            np.array([1.0, 2.0]), np.ones((2, 1)), matrix
+        )
+
+        np.testing.assert_array_equal(theta, [0.0])
+        assert sigma2 == 0.0
+        assert ll == float("-inf")
+
+    def test_ou_profile_inverse_rejects_zero_variance(self, svc):
+        _, sigma2, ll = svc._ou_profile_likelihood_inverse(
+            np.ones(3), np.ones((3, 1)), np.eye(3)
+        )
+
+        assert sigma2 == 0.0
+        assert ll == float("-inf")
+
+    def test_ou_gls_likelihood_falls_back_to_inverse(self, svc, monkeypatch):
+        x = np.array([1.0, 2.0, 4.0])
+        W = np.ones((3, 1))
+        V = np.diag([1.0, 2.0, 3.0])
+        expected = svc._ou_gls_log_likelihood_inverse(x, W, V)
+
+        def fail_cholesky(_x, _W, _V):
+            raise ValueError("factorization failed")
+
+        monkeypatch.setattr(svc, "_ou_gls_log_likelihood_cholesky", fail_cholesky)
+        observed = svc._ou_gls_log_likelihood(x, W, V)
+
+        np.testing.assert_allclose(observed[0], expected[0])
+        assert observed[1] == pytest.approx(expected[1])
+
+    def test_ou_gls_cholesky_uses_least_squares_for_singular_design(self, svc):
+        x = np.array([1.0, 2.0, 3.0])
+        W = np.ones((3, 2))
+
+        theta, ll = svc._ou_gls_log_likelihood_cholesky(x, W, np.eye(3))
+
+        np.testing.assert_allclose(W @ theta, np.full(3, 2.0))
+        assert np.isfinite(ll)
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [np.diag([1.0, -1.0]), np.zeros((2, 2))],
+    )
+    def test_ou_gls_inverse_rejects_invalid_covariances(self, svc, matrix):
+        theta, ll = svc._ou_gls_log_likelihood_inverse(
+            np.array([1.0, 2.0]), np.ones((2, 1)), matrix
+        )
+
+        np.testing.assert_array_equal(theta, [0.0])
+        assert ll == float("-inf")
+
+    def test_fit_model_rejects_unknown_internal_model(self, svc, precomputed):
+        d = precomputed
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc._fit_model(
+                "UNKNOWN",
+                d["x"],
+                d["vcv_total"],
+                d["per_regime_vcv"],
+                d["ordered_names"],
+                d["regimes"],
+                d["lineage_info"],
+                d["root_regime"],
+                d["tree_height"],
+                len(d["regimes"]),
+            )
+
+        assert excinfo.value.messages == ["Unknown model: UNKNOWN"]
+
+    def test_optimize_parameter_handles_invalid_slices_and_failures(
+        self, svc, monkeypatch
+    ):
+        calls = 0
+
+        def fail_minimize(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("optimizer failed")
+
+        monkeypatch.setattr(ouwie_module, "minimize_scalar", fail_minimize)
+
+        assert svc._optimize_parameter(lambda value: value, (1.0, 1.0)) == (
+            1.0,
+            -np.inf,
+        )
+        assert calls == 0
+        assert svc._optimize_parameter(lambda value: value, (0.0, 1.0)) == (
+            0.5,
+            -np.inf,
+        )
+        assert calls == 10
 
     def test_cholesky_bm_likelihood_uses_single_solve(
         self, precomputed, monkeypatch

--- a/tests/unit/services/tree/test_parsimony_score.py
+++ b/tests/unit/services/tree/test_parsimony_score.py
@@ -48,6 +48,21 @@ def test_parsimony_state_symbols_uses_joined_scan_for_many_dna_rows():
     assert module._parsimony_state_symbols(sequences) == ["A", "C", "G", "T"]
 
 
+def test_parsimony_state_symbols_uses_joined_scan_for_many_extra_states():
+    sequences = {
+        f"taxon_{idx}": ("E" if idx == 0 else "A")
+        for idx in range(module._PARSIMONY_JOINED_STATE_SCAN_MIN_SEQUENCES)
+    }
+
+    assert module._parsimony_state_symbols(sequences) == [
+        "A",
+        "C",
+        "E",
+        "G",
+        "T",
+    ]
+
+
 def test_parsimony_state_symbols_preserves_extra_ascii_states():
     sequences = {
         "A": "ACGTacgt-?NX",
@@ -83,6 +98,22 @@ def test_parsimony_state_symbols_preserves_unicode_fallback():
         "T",
         state_one,
         state_two,
+    ]
+
+
+def test_parsimony_state_symbols_preserves_unicode_for_many_rows():
+    unicode_state = chr(256)
+    sequences = {
+        f"taxon_{idx}": (unicode_state if idx == 0 else "A")
+        for idx in range(module._PARSIMONY_JOINED_STATE_SCAN_MIN_SEQUENCES)
+    }
+
+    assert module._parsimony_state_symbols(sequences) == [
+        "A",
+        "C",
+        "G",
+        "T",
+        unicode_state,
     ]
 
 
@@ -129,6 +160,32 @@ class TestParsimonyScoreInit:
 
 
 class TestFitchAlgorithm:
+    @pytest.mark.parametrize(
+        ("parser_result", "expected_message"),
+        [
+            (ValueError("bad FASTA"), "Could not parse alignment from broken.fa."),
+            ({}, "Alignment file is empty."),
+        ],
+        ids=["parser-error", "empty-alignment"],
+    )
+    def test_parse_alignment_reports_invalid_input(
+        self, monkeypatch, args, parser_result, expected_message
+    ):
+        if isinstance(parser_result, Exception):
+            def parse_result(_path):
+                raise parser_result
+        else:
+            def parse_result(_path):
+                return parser_result
+
+        monkeypatch.setattr(module, "read_fasta_first_token_upper", parse_result)
+        ps = ParsimonyScore(args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ps._parse_alignment("broken.fa")
+
+        assert expected_message in exc_info.value.messages
+
     def test_parse_alignment_uses_first_header_token_uppercases_and_keeps_last_duplicate(
         self, tmp_path, args
     ):
@@ -237,6 +294,183 @@ class TestFitchAlgorithm:
 
         assert ps._has_polytomies(binary) is False
         assert ps._has_polytomies(mixed) is True
+
+    def test_tree_traversal_helpers_reject_incompatible_objects(self, args):
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        ps = ParsimonyScore(args)
+
+        assert ps._has_polytomies(object()) is None
+        assert ps._has_polytomies(MalformedTree()) is None
+        assert ps._postorder_clades_fast(object()) is None
+        assert ps._postorder_clades_fast(MalformedTree()) is None
+        assert not ps._resolve_standard_tree_polytomies(object())
+        assert not ps._resolve_standard_tree_polytomies(MalformedTree())
+
+    def test_generic_tree_polytomy_resolution_uses_postorder_fallback(self, args):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1,D:1);"), "newick")
+
+        class GenericTree:
+            def find_clades(self, order):
+                return tree.find_clades(order=order)
+
+        ps._resolve_polytomies(GenericTree())
+
+        assert all(len(clade.clades) <= 2 for clade in tree.find_clades())
+
+    def test_terminal_sequence_check_supports_generic_tree_fallback(self, args):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+
+        class GenericTree:
+            def find_clades(self, order):
+                return tree.find_clades(order=order)
+
+        assert ps._tree_terminals_have_sequences(
+            GenericTree(),
+            {"A": "A", "B": "A", "C": "A"},
+        )
+        assert not ps._tree_terminals_have_sequences(
+            GenericTree(),
+            {"A": "A", "B": "A"},
+        )
+
+    def test_terminal_sequence_check_recovers_from_malformed_direct_tree(
+        self, args
+    ):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+            def find_clades(self, order):
+                return tree.find_clades(order=order)
+
+        assert ps._tree_terminals_have_sequences(
+            MalformedTree(),
+            {"A": "A", "B": "A", "C": "A"},
+        )
+        assert not ps._tree_terminals_have_sequences(
+            MalformedTree(),
+            {"A": "A", "B": "A"},
+        )
+
+    def test_fitch_algorithms_support_generic_postorder_traversal(self, args):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+
+        class GenericTree:
+            def find_clades(self, order):
+                return tree.find_clades(order=order)
+
+        generic_tree = GenericTree()
+        short_sequences = {
+            "A": "AA",
+            "B": "AC",
+            "C": "CC",
+            "D": "CA",
+        }
+        wide_sequences = {
+            taxon: sequence * 9
+            for taxon, sequence in short_sequences.items()
+        }
+
+        assert ps._fitch_parsimony_small(
+            generic_tree, short_sequences, 2
+        ) == ps._fitch_parsimony_small(tree, short_sequences, 2)
+        assert ps._fitch_parsimony_sets(
+            generic_tree, short_sequences, 2
+        ) == ps._fitch_parsimony_sets(tree, short_sequences, 2)
+        assert ps._fitch_parsimony(
+            generic_tree, wide_sequences, 18
+        ) == ps._fitch_parsimony(tree, wide_sequences, 18)
+
+    def test_fitch_algorithms_skip_unresolved_polytomies(self, args):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        short_sequences = {"A": "A", "B": "C", "C": "G"}
+        wide_sequences = {
+            taxon: sequence * 17
+            for taxon, sequence in short_sequences.items()
+        }
+
+        assert ps._fitch_parsimony_small(tree, short_sequences, 1) == (0, [0])
+        assert ps._fitch_parsimony_sets(tree, short_sequences, 1) == (0, [0])
+        assert ps._fitch_parsimony(tree, wide_sequences, 17) == (0, [0] * 17)
+
+    def test_fitch_dispatches_high_cardinality_states_to_set_fallback(self, args):
+        def build_subtree(names):
+            if len(names) == 1:
+                return f"{names[0]}:1"
+            midpoint = len(names) // 2
+            return (
+                f"({build_subtree(names[:midpoint])},"
+                f"{build_subtree(names[midpoint:])}):1"
+            )
+
+        ps = ParsimonyScore(args)
+        taxa = [f"T{idx}" for idx in range(70)]
+        tree = Phylo.read(StringIO(f"{build_subtree(taxa)};"), "newick")
+        states = [chr(0x100 + idx) for idx in range(len(taxa))]
+        short_sequences = {
+            taxon: states[idx]
+            for idx, taxon in enumerate(taxa)
+        }
+        wide_sequences = {
+            taxon: states[idx] * 17
+            for idx, taxon in enumerate(taxa)
+        }
+
+        assert ps._fitch_parsimony(
+            tree, short_sequences, 1
+        ) == ps._fitch_parsimony_sets(tree, short_sequences, 1)
+        assert ps._fitch_parsimony(
+            tree, wide_sequences, 17
+        ) == ps._fitch_parsimony_sets(tree, wide_sequences, 17)
+
+    def test_vectorized_fitch_handles_unicode_state_lookup_fallback(self, args):
+        ps = ParsimonyScore(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        state_one = chr(256)
+        state_two = chr(257)
+        sequences = {
+            "A": state_one + "A" * 16,
+            "B": state_two + "A" * 16,
+            "C": state_one + "C" * 16,
+            "D": state_two + "C" * 16,
+        }
+
+        assert ps._fitch_parsimony(
+            tree, sequences, 17
+        ) == ps._fitch_parsimony_sets(tree, sequences, 17)
+
+    def test_empty_sequence_collection_is_not_identical(self):
+        assert not ParsimonyScore._sequences_are_identical({})
+
+    def test_run_rejects_fewer_than_three_shared_taxa(self, tmp_path):
+        tree_file = tmp_path / "tree.tre"
+        tree_file.write_text("((A:1,B:1):1,C:2);\n")
+        alignment_file = tmp_path / "alignment.fa"
+        alignment_file.write_text(">A\nAC\n>B\nAC\n")
+        ps = ParsimonyScore(
+            Namespace(tree=str(tree_file), alignment=str(alignment_file))
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ps.run()
+
+        assert "Only 2 shared taxa between tree and alignment." in (
+            exc_info.value.messages
+        )
 
     def test_identical_sequences_score_zero(self, tmp_path):
         """All identical sequences should produce score 0."""

--- a/tests/unit/services/tree/test_phenogram.py
+++ b/tests/unit/services/tree/test_phenogram.py
@@ -69,6 +69,89 @@ class TestProcessArgs:
 
 
 class TestTraitParsing:
+    def test_missing_file_reports_path(self, tmp_path):
+        missing_path = tmp_path / "missing-traits.tsv"
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=str(missing_path),
+            output="plot.png",
+            json=False,
+        )
+        svc = Phenogram(args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_single_trait_data(str(missing_path), ["A", "B", "C"])
+
+        assert f"{missing_path} corresponds to no such file or directory." in (
+            exc_info.value.messages
+        )
+
+    def test_reordered_complete_trait_file_is_accepted(self, tmp_path):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("C\t3.0\nA\t1.0\nB\t2.0\n")
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=str(trait_file),
+            output="plot.png",
+            json=False,
+        )
+        svc = Phenogram(args)
+
+        traits = svc._parse_single_trait_data(
+            str(trait_file),
+            ["A", "B", "C"],
+        )
+
+        assert traits == {"C": 3.0, "A": 1.0, "B": 2.0}
+
+    def test_partial_taxon_overlap_warns_and_keeps_shared_values(
+        self, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("B\t2.0\nC\t3.0\nD\t4.0\nE\t5.0\n")
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=str(trait_file),
+            output="plot.png",
+            json=False,
+        )
+        svc = Phenogram(args)
+
+        traits = svc._parse_single_trait_data(
+            str(trait_file),
+            ["A", "B", "C", "D"],
+        )
+
+        assert traits == {"B": 2.0, "C": 3.0, "D": 4.0}
+        assert capsys.readouterr().err.splitlines() == [
+            "Warning: 1 taxa in tree but not in trait file: A",
+            "Warning: 1 taxa in trait file but not in tree: E",
+        ]
+
+    def test_fewer_than_three_shared_taxa_is_rejected(
+        self, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nD\t4.0\n")
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=str(trait_file),
+            output="plot.png",
+            json=False,
+        )
+        svc = Phenogram(args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_single_trait_data(
+                str(trait_file),
+                ["A", "B", "C"],
+            )
+
+        assert "Only 2 shared taxa between tree and trait file." in (
+            exc_info.value.messages
+        )
+        assert "Warning:" in capsys.readouterr().err
+
     def test_comments_and_blanks(self, tmp_path):
         trait_file = tmp_path / "traits.tsv"
         trait_file.write_text(

--- a/tests/unit/services/tree/test_phenogram.py
+++ b/tests/unit/services/tree/test_phenogram.py
@@ -547,6 +547,14 @@ class TestRun:
 
 
 class TestFastAnc:
+    def test_label_internal_nodes_preserves_existing_labels(self):
+        svc = Phenogram.__new__(Phenogram)
+        tree = Phylo.read(StringIO("((A:1,B:1)Named:1,C:2);"), "newick")
+
+        labels = svc._label_internal_nodes(tree)
+
+        assert "Named" in labels.values()
+
     def test_iter_preorder_matches_biopython_order(self):
         svc = Phenogram.__new__(Phenogram)
         tree = Phylo.read(
@@ -658,8 +666,126 @@ class TestFastAnc:
         expected_second = ((3.0 - combined_est) ** 2) / (1.0 + combined_var)
         assert sigma2 == pytest.approx((expected_first + expected_second) / 2.0)
 
+    def test_fast_anc_skips_terminals_without_trait_values(self):
+        svc = Phenogram.__new__(Phenogram)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        labels = svc._label_internal_nodes(tree)
+
+        estimates, sigma2 = svc._fast_anc(
+            tree,
+            np.array([1.0, 2.0]),
+            ["A", "B"],
+            labels,
+        )
+
+        assert estimates
+        assert np.isfinite(sigma2)
+
+    def test_fast_anc_stabilizes_zero_length_branches(self):
+        svc = Phenogram.__new__(Phenogram)
+        tree = Phylo.read(
+            StringIO("((A:0,B:0):0,(C:0,D:0):0);"),
+            "newick",
+        )
+        labels = svc._label_internal_nodes(tree)
+
+        estimates, sigma2 = svc._fast_anc(
+            tree,
+            np.array([1.0, 2.0, 3.0, 4.0]),
+            ["A", "B", "C", "D"],
+            labels,
+        )
+
+        assert set(estimates) == set(labels.values())
+        assert np.isfinite(sigma2)
+
+    def test_sigma2_returns_zero_without_valid_contrasts(self):
+        svc = Phenogram.__new__(Phenogram)
+        tree = Phylo.read(StringIO("(A:0,B:0);"), "newick")
+
+        assert svc._compute_sigma2_from_contrasts(
+            tree,
+            np.array([1.0, 2.0]),
+            {},
+            {},
+            ["A", "B"],
+        ) == pytest.approx(0.0)
+
+    def test_sigma2_handles_zero_variance_contrast(self):
+        svc = Phenogram.__new__(Phenogram)
+        tree = Phylo.read(StringIO("(A:0,B:0);"), "newick")
+        estimates = {id(tip): float(idx) for idx, tip in enumerate(tree.root.clades)}
+        variances = {id(tip): 0.0 for tip in tree.root.clades}
+
+        assert svc._compute_sigma2_from_contrasts(
+            tree,
+            np.array([0.0, 1.0]),
+            estimates,
+            variances,
+            ["A", "B"],
+        ) == pytest.approx(0.0)
+
 
 class TestPlotPhenogram:
+    def test_plot_phenogram_reports_missing_matplotlib(
+        self, monkeypatch, capsys
+    ):
+        svc = Phenogram.__new__(Phenogram)
+        real_import = builtins.__import__
+
+        def fail_matplotlib_import(name, *args, **kwargs):
+            if name == "matplotlib":
+                raise ImportError("matplotlib unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fail_matplotlib_import)
+
+        with pytest.raises(SystemExit) as exc_info:
+            svc._plot_phenogram(None, {}, {}, {}, "trait", "unused.png")
+
+        assert exc_info.value.code == 2
+        assert "matplotlib is required" in capsys.readouterr().out
+
+    def test_plot_phenogram_skips_empty_estimate_range(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=TRAITS_FILE,
+            output=str(tmp_path / "empty.png"),
+            json=False,
+        )
+        svc = Phenogram(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+
+        svc._plot_phenogram(tree, {}, {}, {}, "trait", args.output)
+
+        assert not Path(args.output).exists()
+
+    def test_plot_phenogram_expands_constant_estimate_range(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data=TRAITS_FILE,
+            output=str(tmp_path / "constant.png"),
+            json=False,
+        )
+        svc = Phenogram(args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")
+        node_labels = svc._label_internal_nodes(tree)
+        node_estimates = {label: 1.0 for label in node_labels.values()}
+        trait_values = {"A": 1.0, "B": 1.0, "C": 1.0}
+
+        svc._plot_phenogram(
+            tree,
+            node_estimates,
+            node_labels,
+            trait_values,
+            "trait",
+            args.output,
+        )
+
+        assert Path(args.output).exists()
+
     def test_value_range_scans_values_once(self):
         class SinglePassValues:
             def __init__(self, values):

--- a/tests/unit/services/tree/test_phylo_heatmap.py
+++ b/tests/unit/services/tree/test_phylo_heatmap.py
@@ -279,6 +279,17 @@ class TestTraitParsing:
 
 
 class TestPhyloHeatmapPlot:
+    def test_clustered_columns_render_dendrogram(self, args):
+        pytest.importorskip("matplotlib")
+        pytest.importorskip("scipy")
+        args.cluster_columns = True
+        ph = PhyloHeatmap(args)
+
+        ph.run()
+
+        assert Path(args.output).exists()
+        assert Path(args.output).stat().st_size > 0
+
     @pytest.mark.parametrize(
         "tree",
         [

--- a/tests/unit/services/tree/test_phylo_heatmap.py
+++ b/tests/unit/services/tree/test_phylo_heatmap.py
@@ -98,6 +98,24 @@ class TestPhyloHeatmapInit:
 
 
 class TestTraitParsing:
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            "# comment\n\n",
+            "taxon\nA\nB\nC\n",
+            "taxon\ttrait\n# no data\n",
+        ],
+    )
+    def test_structurally_empty_matrices_are_rejected(
+        self, args, tmp_path, contents
+    ):
+        ph = PhyloHeatmap(args)
+        trait_file = tmp_path / "invalid.tsv"
+        trait_file.write_text(contents)
+
+        with pytest.raises(SystemExit):
+            ph._parse_trait_matrix(str(trait_file), ["A", "B", "C"])
+
     def test_parse_multi_column_tsv(self, args):
         ph = PhyloHeatmap(args)
         tree = ph.read_tree_file()
@@ -225,8 +243,52 @@ class TestTraitParsing:
         with pytest.raises(SystemExit):
             ph._parse_trait_matrix(str(f), ["A", "B", "C"])
 
+    def test_unordered_exact_taxa_emit_no_warnings(self, args, tmp_path, capsys):
+        ph = PhyloHeatmap(args)
+        trait_file = tmp_path / "unordered.tsv"
+        trait_file.write_text(
+            "taxon\ttrait\nC\t3.0\nA\t1.0\nB\t2.0\n"
+        )
+
+        names, data = ph._parse_trait_matrix(
+            str(trait_file), ["A", "B", "C"]
+        )
+
+        assert names == ["trait"]
+        assert data == {"C": [3.0], "A": [1.0], "B": [2.0]}
+        assert capsys.readouterr().err == ""
+
+    def test_taxon_mismatches_warn_and_return_shared_data(
+        self, args, tmp_path, capsys
+    ):
+        ph = PhyloHeatmap(args)
+        trait_file = tmp_path / "mismatch.tsv"
+        trait_file.write_text(
+            "taxon\ttrait\nA\t1.0\nB\t2.0\nC\t3.0\nextra\t4.0\n"
+        )
+
+        names, data = ph._parse_trait_matrix(
+            str(trait_file), ["A", "B", "C", "missing"]
+        )
+
+        assert names == ["trait"]
+        assert data == {"A": [1.0], "B": [2.0], "C": [3.0]}
+        stderr = capsys.readouterr().err
+        assert "missing" in stderr
+        assert "extra" in stderr
+
 
 class TestPhyloHeatmapPlot:
+    @pytest.mark.parametrize(
+        "tree",
+        [
+            Namespace(root=object()),
+            Namespace(root=Namespace(clades=[object()])),
+        ],
+    )
+    def test_default_branch_length_scan_handles_generic_trees(self, tree):
+        assert PhyloHeatmap._needs_default_branch_lengths(tree) is True
+
     def test_build_heatmap_matrix_uses_typed_asarray(self, monkeypatch):
         trait_data = {
             "B": [3, 4],

--- a/tests/unit/services/tree/test_phylo_heatmap.py
+++ b/tests/unit/services/tree/test_phylo_heatmap.py
@@ -279,6 +279,33 @@ class TestTraitParsing:
 
 
 class TestPhyloHeatmapPlot:
+    def test_circular_constant_matrix_with_color_annotations(self, args, tmp_path):
+        pytest.importorskip("matplotlib")
+        tree = Phylo.read(args.tree, "newick")
+        taxa = [tip.name for tip in tree.get_terminals()]
+        data_file = tmp_path / "constant.tsv"
+        data_file.write_text(
+            "taxon\tconstant\n"
+            + "".join(f"{taxon}\t1.0\n" for taxon in taxa)
+        )
+        color_file = tmp_path / "colors.tsv"
+        color_file.write_text(
+            "bear,raccoon\trange\t#ffcc00\tRange\n"
+            "bear,raccoon\tclade\t#cc0033\tClade\n"
+            "bear\tlabel\t#0033cc\n"
+        )
+        args.data = str(data_file)
+        args.output = str(tmp_path / "circular-constant.png")
+        args.circular = True
+        args.standardize = True
+        args.color_file = str(color_file)
+        ph = PhyloHeatmap(args)
+
+        ph.run()
+
+        assert Path(args.output).exists()
+        assert Path(args.output).stat().st_size > 0
+
     def test_clustered_columns_render_dendrogram(self, args):
         pytest.importorskip("matplotlib")
         pytest.importorskip("scipy")

--- a/tests/unit/services/tree/test_phylo_logistic.py
+++ b/tests/unit/services/tree/test_phylo_logistic.py
@@ -11,6 +11,7 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 from Bio import Phylo
+from Bio.Phylo.BaseTree import Clade
 
 from phykit.services.tree.phylo_logistic import PhyloLogistic
 import phykit.services.tree.phylo_logistic as phylo_logistic_module
@@ -286,6 +287,14 @@ def test_standard_errors_from_info_matrix_keeps_inverse_fallback():
     np.testing.assert_allclose(observed, expected)
 
 
+def test_standard_errors_return_nan_for_singular_information():
+    observed = phylo_logistic_module._standard_errors_from_info_matrix(
+        np.zeros((2, 2))
+    )
+
+    assert np.isnan(observed).all()
+
+
 @pytest.fixture
 def basic_args():
     return Namespace(
@@ -365,8 +374,102 @@ class TestProcessArgs:
         parsed = svc.process_args(args)
         assert parsed["predictors"] == ["x1", "x2", "x3"]
 
+    def test_predictor_list_is_preserved(self):
+        args = Namespace(
+            tree="t.tre",
+            trait_data="d.tsv",
+            response="y",
+            predictor=["x1", "x2"],
+        )
+
+        parsed = PhyloLogistic.__new__(PhyloLogistic).process_args(args)
+
+        assert parsed["predictors"] == ["x1", "x2"]
+
+    @pytest.mark.parametrize(
+        ("p_value", "expected"),
+        [
+            (0.0005, "***"),
+            (0.005, "**"),
+            (0.02, "*"),
+            (0.08, "."),
+            (0.5, " "),
+        ],
+    )
+    def test_significance_code_boundaries(self, p_value, expected):
+        svc = PhyloLogistic.__new__(PhyloLogistic)
+
+        assert svc._signif_code(p_value) == expected
+
 
 class TestTransformedVCV:
+    def test_root_tip_distances_support_tree_protocol_fallbacks(self, basic_args):
+        svc = PhyloLogistic(basic_args)
+        root = object()
+        tip_a = Clade(name="A")
+        tip_b = Clade(name="B")
+
+        class DepthTree:
+            def __init__(self):
+                self.root = root
+
+            def depths(self):
+                return {root: 2.0, tip_a: 5.0, tip_b: 9.0}
+
+            def get_terminals(self):
+                return [tip_a, tip_b]
+
+        class DistanceTree:
+            def __init__(self):
+                self.root = root
+
+            def depths(self):
+                raise TypeError("depths unavailable")
+
+            def distance(self, tree_root, name):
+                assert tree_root is root
+                return {"A": 3.0, "B": 7.0}[name]
+
+        np.testing.assert_allclose(
+            svc._root_tip_distances(DepthTree(), ["B", "A"]),
+            [7.0, 3.0],
+        )
+        np.testing.assert_allclose(
+            svc._root_tip_distances(DistanceTree(), ["A", "B"]),
+            [3.0, 7.0],
+        )
+
+    def test_transformed_vcv_handles_nonpositive_branch_callback(
+        self, basic_args, monkeypatch
+    ):
+        from phykit.services.tree import vcv_utils
+
+        svc = PhyloLogistic(basic_args)
+        tree = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+        observed = {}
+
+        def transformed_builder(tree_arg, names, transform):
+            assert tree_arg is tree
+            assert names == ["A", "B"]
+            observed["zero"] = transform(0.0)
+            observed["positive"] = transform(2.0)
+            return np.eye(2)
+
+        monkeypatch.setattr(
+            vcv_utils, "build_transformed_vcv_matrix", transformed_builder
+        )
+
+        matrix, _diag = svc._build_logistic_vcv(
+            tree,
+            0.5,
+            ["A", "B"],
+            vcv_utils.build_vcv_matrix,
+            np.array([1.0, 1.0]),
+        )
+
+        assert observed["zero"] == 0.0
+        assert observed["positive"] > 0.0
+        assert np.all(np.diag(matrix) > 1.0)
     def test_transformed_vcv_alpha_zero(self, basic_args):
         """When alpha ~ 0, the transformed VCV should be the standard BM VCV."""
         from phykit.services.tree.vcv_utils import build_vcv_matrix
@@ -613,6 +716,100 @@ class TestTransformedVCV:
 
 
 class TestFit:
+    def test_singular_starting_value_system_returns_current_estimate(self):
+        svc = PhyloLogistic.__new__(PhyloLogistic)
+        X = np.ones((4, 2))
+        y = np.array([0.0, 1.0, 0.0, 1.0])
+
+        beta = svc._logistic_starting_values(y, X)
+
+        np.testing.assert_allclose(beta, np.zeros(2))
+
+    def test_info_matrix_falls_back_to_inverse(self, basic_args, monkeypatch):
+        svc = PhyloLogistic(basic_args)
+        expected = np.array([[3.0]])
+
+        def fail_cholesky(*_args, **_kwargs):
+            raise np.linalg.LinAlgError("not positive definite")
+
+        monkeypatch.setattr(svc, "_compute_info_matrix_cholesky", fail_cholesky)
+        monkeypatch.setattr(
+            svc, "_compute_info_matrix_inverse", lambda *_args: expected
+        )
+
+        observed = svc._compute_info_matrix(
+            np.ones((2, 1)), np.full(2, 0.5), np.eye(2)
+        )
+
+        assert observed is expected
+
+    def test_info_matrix_inverse_regularizes_singular_vcv(self, basic_args):
+        svc = PhyloLogistic(basic_args)
+
+        observed = svc._compute_info_matrix_inverse(
+            np.ones((2, 2)), np.full(2, 0.5), np.zeros((2, 2))
+        )
+
+        np.testing.assert_allclose(observed, np.eye(2) * 1e-10)
+
+    def test_penalized_likelihood_rejects_vcv_failure(
+        self, basic_args, monkeypatch
+    ):
+        svc = PhyloLogistic(basic_args)
+        monkeypatch.setattr(
+            svc,
+            "_build_logistic_vcv",
+            lambda *_args: (_ for _ in ()).throw(ValueError("bad VCV")),
+        )
+
+        observed = svc._neg_pen_loglik(
+            np.array([0.0, 0.0]),
+            np.ones((2, 1)),
+            np.array([0.0, 1.0]),
+            object(),
+            ["A", "B"],
+            object(),
+            np.ones(2),
+        )
+
+        assert observed == 1e10
+
+    def test_penalized_likelihood_rejects_nonfinite_and_singular_terms(
+        self, basic_args, monkeypatch
+    ):
+        svc = PhyloLogistic(basic_args)
+        monkeypatch.setattr(
+            svc, "_build_logistic_vcv", lambda *_args: (np.eye(2), np.ones(2))
+        )
+        args = (
+            np.array([0.0, 0.0]),
+            np.ones((2, 1)),
+            np.array([0.0, 1.0]),
+            object(),
+            ["A", "B"],
+            object(),
+            np.ones(2),
+        )
+
+        monkeypatch.setattr(
+            phylo_logistic_module, "_bernoulli_log_likelihood", lambda *_args: np.nan
+        )
+        assert svc._neg_pen_loglik(*args) == 1e10
+
+        monkeypatch.setattr(
+            phylo_logistic_module, "_bernoulli_log_likelihood", lambda *_args: -1.0
+        )
+        monkeypatch.setattr(
+            svc, "_compute_info_matrix", lambda *_args: np.array([[-1.0]])
+        )
+        assert svc._neg_pen_loglik(*args) == 1e10
+
+        def fail_slogdet(_matrix):
+            raise np.linalg.LinAlgError("singular")
+
+        monkeypatch.setattr(phylo_logistic_module.np.linalg, "slogdet", fail_slogdet)
+        assert svc._neg_pen_loglik(*args) == 1e10
+
     def test_logistic_starting_values_match_diagonal_weight_reference(self, monkeypatch):
         svc = PhyloLogistic.__new__(PhyloLogistic)
         rng = np.random.default_rng(20260623)
@@ -722,6 +919,74 @@ class TestFit:
 
 
 class TestValidation:
+    def test_insufficient_observations_for_predictor_count(self, mocker):
+        args = Namespace(
+            tree=TREE_SIMPLE,
+            trait_data="traits.tsv",
+            response="y",
+            predictor=["x1", "x2"],
+            json=False,
+        )
+        svc = PhyloLogistic(args)
+        tree = object()
+        mocker.patch.object(svc, "read_tree_file_unmodified", return_value=tree)
+        mocker.patch.object(svc, "validate_tree")
+        mocker.patch.object(
+            svc, "get_tip_names_from_tree", return_value=["A", "B", "C"]
+        )
+        mocker.patch(
+            "phykit.services.tree.phylo_logistic.parse_multi_trait_file",
+            return_value=(
+                ["y", "x1", "x2"],
+                {
+                    "A": [0.0, 1.0, 2.0],
+                    "B": [1.0, 2.0, 3.0],
+                    "C": [0.0, 3.0, 4.0],
+                },
+            ),
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert "Insufficient observations" in exc_info.value.messages[0]
+
+    @pytest.mark.parametrize(
+        ("response", "message"),
+        [
+            (np.array([0.0, 1.0, 2.0, 0.0]), "only 0 and 1"),
+            (np.zeros(4), "must contain both"),
+        ],
+    )
+    def test_invalid_binary_responses(self, mocker, basic_args, response, message):
+        svc = PhyloLogistic(basic_args)
+        tree = object()
+        mocker.patch.object(svc, "read_tree_file_unmodified", return_value=tree)
+        mocker.patch.object(svc, "validate_tree")
+        mocker.patch.object(
+            svc, "get_tip_names_from_tree", return_value=["A", "B", "C", "D"]
+        )
+        mocker.patch(
+            "phykit.services.tree.phylo_logistic.parse_multi_trait_file",
+            return_value=(
+                ["has_wings", "body_mass"],
+                {
+                    "A": [0.0, 1.0],
+                    "B": [1.0, 2.0],
+                    "C": [0.0, 3.0],
+                    "D": [1.0, 4.0],
+                },
+            ),
+        )
+        mocker.patch(
+            "phykit.services.tree.phylo_logistic.response_predictor_arrays",
+            return_value=(response, np.ones((4, 2))),
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert message in exc_info.value.messages[0]
     def test_missing_column(self, basic_args):
         basic_args.response = "nonexistent_column"
         svc = PhyloLogistic(basic_args)

--- a/tests/unit/services/tree/test_phylogenetic_ordination.py
+++ b/tests/unit/services/tree/test_phylogenetic_ordination.py
@@ -659,6 +659,87 @@ class TestPhylogeneticPCALambda:
     REF_LOG_LIKELIHOOD = -6.016939
     REF_EIGENVALUES = [0.076301214816, 0.002241847818, 0.000315397635]
 
+    def test_centering_and_likelihood_use_inverse_fallbacks(
+        self, lambda_args, monkeypatch
+    ):
+        svc = PhylogeneticOrdination(lambda_args)
+        Y = np.arange(12.0).reshape(4, 3)
+        C = np.eye(4)
+        expected_center = (np.ones_like(Y), None)
+
+        def fail_center(*_args, **_kwargs):
+            raise np.linalg.LinAlgError("cholesky failed")
+
+        def fail_likelihood(*_args, **_kwargs):
+            raise np.linalg.LinAlgError("cholesky failed")
+
+        monkeypatch.setattr(svc, "_center_traits_by_vcv_cholesky", fail_center)
+        monkeypatch.setattr(
+            svc, "_center_traits_by_vcv_inverse", lambda *_args: expected_center
+        )
+        monkeypatch.setattr(
+            svc, "_multi_trait_log_likelihood_cholesky", fail_likelihood
+        )
+        monkeypatch.setattr(
+            svc, "_multi_trait_log_likelihood_inverse", lambda *_args: -12.5
+        )
+
+        assert svc._center_traits_by_vcv(Y, C) is expected_center
+        assert svc._multi_trait_log_likelihood(Y, C) == -12.5
+
+    def test_centering_without_weighted_matrix(self, lambda_args):
+        svc = PhylogeneticOrdination(lambda_args)
+        Y = np.arange(12.0).reshape(4, 3)
+        C = np.eye(4)
+
+        centered_cholesky, weighted_cholesky = (
+            svc._center_traits_by_vcv_cholesky(Y, C, include_weighted=False)
+        )
+        centered_inverse, weighted_inverse = svc._center_traits_by_vcv_inverse(
+            Y, C, include_weighted=False
+        )
+
+        np.testing.assert_allclose(centered_cholesky, centered_inverse)
+        assert weighted_cholesky is None
+        assert weighted_inverse is None
+
+    def test_likelihood_rejects_singular_trait_covariance(self, lambda_args):
+        svc = PhylogeneticOrdination(lambda_args)
+        Y = np.ones((4, 2))
+        C = np.eye(4)
+
+        assert svc._multi_trait_log_likelihood_cholesky(Y, C) == -1e20
+        assert svc._multi_trait_log_likelihood_inverse(Y, C) == -1e20
+
+    def test_lambda_search_penalizes_failed_candidates(
+        self, lambda_args, monkeypatch
+    ):
+        svc = PhylogeneticOrdination(lambda_args)
+        calls = 0
+
+        def likelihood(_Y, _C):
+            nonlocal calls
+            calls += 1
+            if calls <= 10:
+                raise np.linalg.LinAlgError("invalid candidate")
+            return -7.0
+
+        def minimize(fn, bounds, method):
+            midpoint = sum(bounds) / 2.0
+            return Namespace(x=midpoint, fun=fn(midpoint))
+
+        monkeypatch.setattr(svc, "_multi_trait_log_likelihood", likelihood)
+        monkeypatch.setattr(
+            phylogenetic_ordination_module, "minimize_scalar", minimize
+        )
+
+        lambda_value, log_likelihood = svc._multi_trait_lambda(
+            np.ones((3, 2)), np.eye(3), 1.0
+        )
+
+        assert 0.0 <= lambda_value <= 1.0
+        assert log_likelihood == -7.0
+
     def test_multi_trait_log_likelihood_cholesky_matches_inverse(self, lambda_args):
         rng = np.random.default_rng(20260623)
         svc = PhylogeneticOrdination(lambda_args)
@@ -940,6 +1021,15 @@ class TestPhylogeneticPCALambda:
 
 
 class TestTSNEEmbedding:
+    def test_explicit_perplexity_below_one_is_rejected(self, tsne_args):
+        tsne_args.perplexity = 0.5
+        svc = PhylogeneticOrdination(tsne_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._embed_tsne(np.ones((4, 2)), 4)
+
+        assert "perplexity >= 1" in exc_info.value.messages[0]
+
     def test_shape(self, tsne_args):
         svc = PhylogeneticOrdination(tsne_args)
         tree = svc.read_tree_file()
@@ -1001,6 +1091,15 @@ class TestTSNEEmbedding:
 
 
 class TestUMAPEmbedding:
+    def test_explicit_neighbor_count_below_two_is_rejected(self, umap_args):
+        umap_args.n_neighbors = 1
+        svc = PhylogeneticOrdination(umap_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._embed_umap(np.ones((3, 2)), 3)
+
+        assert "n_neighbors >= 2" in exc_info.value.messages[0]
+
     def test_shape(self, umap_args):
         svc = PhylogeneticOrdination(umap_args)
         tree = svc.read_tree_file()

--- a/tests/unit/services/tree/test_phylogenetic_ordination.py
+++ b/tests/unit/services/tree/test_phylogenetic_ordination.py
@@ -1264,6 +1264,23 @@ class TestSmallSampleGuards:
 
 
 class TestTreeColorTrait:
+    def test_invalid_tree_color_sources_return_no_reconstruction(
+        self, default_args, tmp_path
+    ):
+        svc = PhylogeneticOrdination(default_args)
+        tree = svc.read_tree_file()
+        taxa = svc.get_tip_names_from_tree(tree)
+        Y = np.ones((len(taxa), 1))
+        nonnumeric = tmp_path / "nonnumeric.tsv"
+        nonnumeric.write_text("".join(f"{taxon}\tbad\n" for taxon in taxa))
+
+        assert svc._resolve_tree_color_trait(
+            "missing-column", ["trait"], Y, taxa, tree
+        ) == (None, None, None)
+        assert svc._resolve_tree_color_trait(
+            str(nonnumeric), ["trait"], Y, taxa, tree
+        ) == (None, None, None)
+
     def test_resolve_tree_color_trait_streams_color_file_once(self, monkeypatch):
         class StreamingOnlyFile:
             def __enter__(self):
@@ -1357,6 +1374,40 @@ class TestTreeColorTrait:
 
 
 class TestRun:
+    def test_generic_five_dimension_outputs(self, default_args, capsys):
+        svc = PhylogeneticOrdination(default_args)
+        svc.n_components = 5
+        labels = [f"PC{i}" for i in range(1, 6)]
+        eigenvalues = np.arange(5.0, 0.0, -1.0)
+        proportions = eigenvalues / eigenvalues.sum()
+        eigenvectors = np.arange(15.0).reshape(3, 5)
+        scores = np.arange(10.0).reshape(2, 5)
+
+        svc._print_pca_text_output(
+            eigenvalues,
+            proportions,
+            eigenvectors,
+            scores,
+            ["trait1", "trait2", "trait3"],
+            ["A", "B"],
+            labels,
+            None,
+            None,
+        )
+        pca_output = capsys.readouterr().out
+        assert "PC5" in pca_output
+        assert "trait3" in pca_output
+
+        result = svc._format_dimreduce_result(
+            scores, ["A", "B"], {}, None, None
+        )
+        svc._print_dimreduce_text_output(
+            scores, ["A", "B"], {}, None, None
+        )
+        dimreduce_output = capsys.readouterr().out
+
+        assert result["embedding"]["A"]["Dim5"] == 4.0
+        assert "Dim5" in dimreduce_output
     def test_run_uses_unmodified_tree_read(self, mocker):
         args = Namespace(
             tree="/some/path/to/file.tre",
@@ -2309,6 +2360,16 @@ class TestPlot:
 
 
 class TestReconstructAncestralScores:
+    @pytest.mark.parametrize(
+        "tree",
+        [
+            Namespace(root=object()),
+            Namespace(root=Namespace(clades=[object()])),
+        ],
+    )
+    def test_direct_preorder_rejects_generic_and_malformed_trees(self, tree):
+        assert PhylogeneticOrdination._preorder_clades_direct(tree) is None
+
     def test_prune_setup_uses_fast_tip_names_and_shared_prune_helper(
         self, default_args, mocker
     ):
@@ -2575,6 +2636,21 @@ class TestReconstructAncestralScores:
 
 
 class TestParseColorBy:
+    def test_file_missing_taxon_values_is_rejected(self, default_args, tmp_path):
+        svc = PhylogeneticOrdination(default_args)
+        color_file = tmp_path / "incomplete.tsv"
+        color_file.write_text("A\tgroup1\nB\tgroup2\n")
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_color_by(
+                str(color_file),
+                ["trait"],
+                np.ones((3, 1)),
+                ["A", "B", "C"],
+            )
+
+        assert "missing values for taxa: C" in exc_info.value.messages[0]
+
     def test_column_name_match(self, default_args):
         svc = PhylogeneticOrdination(default_args)
         tree = svc.read_tree_file()

--- a/tests/unit/services/tree/test_polytomy_test.py
+++ b/tests/unit/services/tree/test_polytomy_test.py
@@ -3,6 +3,7 @@ Unit tests for PolytomyTest class
 """
 
 import unittest
+import math
 import subprocess
 import sys
 from unittest.mock import Mock, MagicMock, patch, mock_open
@@ -76,6 +77,183 @@ class TestPolytomyTest(unittest.TestCase):
         """Test initialization"""
         self.assertEqual(self.polytomy.trees, "test_trees.txt")
         self.assertEqual(self.polytomy.groups, "test_groups.txt")
+
+    def test_lazy_helper_wrappers_delegate(self):
+        with patch(
+            "phykit.helpers.json_output.print_json", return_value="json"
+        ) as print_mock:
+            self.assertEqual(module.print_json({"value": 1}), "json")
+            print_mock.assert_called_once_with({"value": 1})
+
+        with patch(
+            "phykit.helpers.files.read_single_column_file_to_list",
+            return_value=["tree.nwk"],
+        ) as read_mock:
+            self.assertEqual(
+                module.read_single_column_file_to_list("trees.txt"),
+                ["tree.nwk"],
+            )
+            read_mock.assert_called_once_with("trees.txt")
+
+    def test_lazy_parallel_wrappers_delegate(self):
+        lazy_mp = module._LazyMultiprocessing()
+        pool = object()
+
+        with patch("multiprocessing.cpu_count", return_value=3), patch(
+            "multiprocessing.Pool", return_value=pool
+        ) as pool_mock:
+            self.assertEqual(lazy_mp.cpu_count(), 3)
+            self.assertIs(lazy_mp.Pool(processes=2), pool)
+            pool_mock.assert_called_once_with(processes=2)
+
+        executor = module.ThreadPoolExecutor(max_workers=1)
+        try:
+            self.assertEqual(executor.submit(abs, -2).result(), 2)
+        finally:
+            executor.shutdown()
+
+    def test_chisquare_fallback_dimensions_and_zero_counts(self):
+        two_counts = module.chisquare([1, 3])
+        four_counts = module.chisquare([1, 2, 3, 4])
+        zero_counts = module.chisquare([0, 0, 0, 0])
+
+        self.assertGreaterEqual(two_counts.pvalue, 0.0)
+        self.assertLessEqual(two_counts.pvalue, 1.0)
+        self.assertGreaterEqual(four_counts.pvalue, 0.0)
+        self.assertLessEqual(four_counts.pvalue, 1.0)
+        self.assertTrue(math.isnan(zero_counts.statistic))
+        self.assertTrue(math.isnan(zero_counts.pvalue))
+
+    def test_chisquare_recovers_when_length_lookup_fails(self):
+        class Values:
+            def __len__(self):
+                raise TypeError("length unavailable")
+
+            def __iter__(self):
+                return iter([1, 3])
+
+        result = module.chisquare(Values())
+
+        self.assertGreater(result.statistic, 0.0)
+
+    def test_chisquare_kwargs_delegate_to_scipy(self):
+        sentinel = object()
+        with patch("scipy.stats.chisquare", return_value=sentinel) as scipy_mock:
+            observed = module.chisquare([1, 2, 3], ddof=1)
+
+        self.assertIs(observed, sentinel)
+        scipy_mock.assert_called_once_with([1, 2, 3], ddof=1)
+
+    def test_safe_copy_falls_back_to_deepcopy_for_local_class(self):
+        class LocalValue:
+            def __init__(self):
+                self.items = [1, 2, 3]
+
+        original = LocalValue()
+
+        copied = self.polytomy._safe_copy(original)
+
+        self.assertIsNot(copied, original)
+        self.assertEqual(copied.items, original.items)
+
+    def test_read_tree_cache_reads_once_and_returns_copies(self):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        with patch.object(module.Phylo, "read", return_value=tree) as read_mock:
+            first = self.polytomy._read_tree_with_cache("tree.nwk")
+            second = self.polytomy._read_tree_with_cache("tree.nwk")
+
+        self.assertEqual(read_mock.call_count, 1)
+        self.assertIsNot(first, second)
+        self.assertEqual(
+            [tip.name for tip in first.get_terminals()],
+            [tip.name for tip in second.get_terminals()],
+        )
+
+    def test_postorder_and_terminal_cache_fallbacks(self):
+        self.assertIsNone(self.polytomy._iter_postorder_clades(object()))
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        self.assertIsNone(self.polytomy._iter_postorder_clades(MalformedTree()))
+
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        with patch.object(
+            self.polytomy,
+            "_iter_postorder_clades",
+            return_value=None,
+        ):
+            cache = self.polytomy._build_clade_terminal_cache(tree)
+
+        self.assertEqual(cache[id(tree.root)], frozenset({"A", "B", "C"}))
+
+    def test_find_sister_pair_handles_binary_and_unresolved_assignments(self):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        cache = self.polytomy._build_clade_terminal_cache(tree)
+
+        self.assertEqual(
+            self.polytomy._find_sister_pair(tree, ("A", "B", "C"), cache),
+            ("A", "B"),
+        )
+
+        polytomy = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        polytomy_cache = self.polytomy._build_clade_terminal_cache(polytomy)
+        self.assertIsNone(
+            self.polytomy._find_sister_pair(
+                polytomy,
+                ("A", "B", "C"),
+                polytomy_cache,
+            )
+        )
+
+    def test_find_sister_pair_returns_none_for_two_singleton_assignments(self):
+        child_a = Newick.Clade(name="A")
+        child_b = Newick.Clade(name="B")
+        root = Newick.Clade(clades=[child_a, child_b])
+
+        class PartialTree:
+            def common_ancestor(self, _triplet):
+                return root
+
+        cache = {id(child_a): ("A",), id(child_b): ("B",)}
+
+        self.assertIsNone(
+            self.polytomy._find_sister_pair(
+                PartialTree(),
+                ("A", "B", "missing"),
+                cache,
+            )
+        )
+
+    def test_legacy_triplet_pass_aggregates_supported_relationship(self):
+        groups = {"test": [["A"], ["B"], ["C"]]}
+        tree = Mock()
+        tree.get_terminals = Mock(return_value=[object(), object(), object()])
+
+        with patch.object(self.polytomy, "get_triplet_tree", return_value=tree), patch.object(
+            self.polytomy, "_has_exactly_three_terminals", return_value=True
+        ), patch.object(
+            self.polytomy, "count_number_of_groups_in_triplet", return_value=3
+        ), patch.object(
+            self.polytomy, "get_tip_names_from_tree", return_value=["A", "B", "C"]
+        ), patch.object(
+            self.polytomy, "set_branch_lengths_in_tree_to_one"
+        ), patch.object(
+            self.polytomy,
+            "determine_sisters_and_add_to_counter",
+            return_value={"tree.nwk": {"0-1": 2}},
+        ):
+            observed = self.polytomy._legacy_triplet_pass(
+                ["A", "B", "C"],
+                "tree.nwk",
+                groups,
+                [],
+            )
+
+        self.assertEqual(observed, {"0-1": 2})
 
     def test_process_args(self):
         """Test argument processing"""

--- a/tests/unit/services/tree/test_polytomy_test.py
+++ b/tests/unit/services/tree/test_polytomy_test.py
@@ -124,6 +124,22 @@ class TestPolytomyTest(unittest.TestCase):
         self.assertTrue(math.isnan(zero_counts.statistic))
         self.assertTrue(math.isnan(zero_counts.pvalue))
 
+        zero_triplet = module.chisquare([0, 0, 0])
+        self.assertTrue(math.isnan(zero_triplet.statistic))
+        self.assertTrue(math.isnan(zero_triplet.pvalue))
+
+    def test_chisquare_fallback_handles_three_iterated_values(self):
+        class Values:
+            def __len__(self):
+                return 4
+
+            def __iter__(self):
+                return iter([1, 2, 3])
+
+        result = module.chisquare(Values())
+
+        self.assertEqual(result.pvalue, math.exp(-result.statistic / 2.0))
+
     def test_chisquare_recovers_when_length_lookup_fails(self):
         class Values:
             def __len__(self):
@@ -190,6 +206,24 @@ class TestPolytomyTest(unittest.TestCase):
 
         self.assertEqual(cache[id(tree.root)], frozenset({"A", "B", "C"}))
 
+        with patch.object(
+            PolytomyTest,
+            "_iter_postorder_clades",
+            return_value=None,
+        ):
+            fallback_cache = self.polytomy._build_clade_terminal_cache(tree)
+        self.assertEqual(
+            fallback_cache[id(tree.root)], frozenset({"A", "B", "C"})
+        )
+
+        class TupleRoot:
+            clades = ()
+
+        class TupleTree:
+            root = TupleRoot()
+
+        self.assertIsNone(self.polytomy._iter_postorder_clades(TupleTree()))
+
     def test_find_sister_pair_handles_binary_and_unresolved_assignments(self):
         tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
         cache = self.polytomy._build_clade_terminal_cache(tree)
@@ -227,6 +261,122 @@ class TestPolytomyTest(unittest.TestCase):
                 cache,
             )
         )
+
+    def test_path_cache_sister_detection_handles_missing_and_unresolved_lca(self):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        clade_cache = self.polytomy._build_clade_terminal_cache(tree)
+        path_cache = self.polytomy._build_tip_path_cache(tree)
+
+        self.assertIsNone(
+            self.polytomy._find_sister_pair_from_path_cache(
+                ("A", "B", "missing"),
+                clade_cache,
+                path_cache,
+            )
+        )
+        self.assertIsNone(
+            self.polytomy._find_sister_pair_from_path_cache(
+                ("A", "B", "C"),
+                clade_cache,
+                path_cache,
+            )
+        )
+
+        path = path_cache["A"]
+        self.assertIs(
+            self.polytomy._common_ancestor_from_path_cache(
+                ("A", "A", "A"),
+                {"A": path},
+            ),
+            path[-1],
+        )
+
+    def test_fast_triplet_evaluation_handles_empty_and_incomplete_groups(self):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+
+        self.assertEqual(self.polytomy._evaluate_tree_triplets_fast(tree, {}), {})
+        self.assertEqual(
+            self.polytomy._evaluate_tree_triplets_fast(
+                tree,
+                {"empty": []},
+            ),
+            {},
+        )
+        self.assertEqual(
+            self.polytomy._evaluate_tree_triplets_fast(
+                tree,
+                {"missing": [["A"], ["B"], ["missing"]]},
+            ),
+            {},
+        )
+        self.assertEqual(
+            self.polytomy._evaluate_tree_triplets_fast(
+                Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick"),
+                {"unresolved": [["A"], ["B"], ["C"]]},
+            ),
+            {},
+        )
+
+    def test_prepare_tree_for_triplets_roots_copy_on_outgroup(self):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+
+        prepared = self.polytomy._prepare_tree_for_triplets(tree, ["D"])
+
+        self.assertIsNot(prepared, tree)
+        self.assertEqual(
+            {tip.name for tip in prepared.get_terminals()},
+            {"A", "B", "C", "D"},
+        )
+
+    def test_sequential_tree_loop_reports_missing_file(self):
+        with patch.object(
+            self.polytomy,
+            "_should_use_multiprocessing",
+            return_value=False,
+        ), patch.object(
+            module.Phylo,
+            "read",
+            side_effect=FileNotFoundError,
+        ), patch.object(
+            module.sys,
+            "exit",
+        ) as exit_mock, patch("builtins.print") as print_mock:
+            observed = self.polytomy.loop_through_trees_and_examine_sister_support_among_triplets(
+                ["missing.nwk"],
+                {"test": [["A"], ["B"], ["C"]]},
+                [],
+            )
+
+        self.assertEqual(observed, {})
+        exit_mock.assert_called_once_with(2)
+        self.assertEqual(print_mock.call_count, 2)
+
+    def test_malformed_tree_scans_use_generic_fallbacks(self):
+        class GenericTree:
+            def __init__(self):
+                self.root = Newick.Clade(clades=[object()])
+                self.clades = [
+                    Newick.Clade(name="A"),
+                    Newick.Clade(name="B"),
+                    Newick.Clade(name="C"),
+                ]
+
+            def find_clades(self):
+                return self.clades
+
+            def get_terminals(self):
+                return self.clades
+
+            def get_nonterminals(self):
+                return [self.root]
+
+        tree = GenericTree()
+
+        self.polytomy.set_branch_lengths_in_tree_to_one(tree)
+
+        self.assertTrue(all(clade.branch_length == 1 for clade in tree.clades))
+        self.assertTrue(self.polytomy._has_exactly_three_terminals(tree))
+        self.assertTrue(self.polytomy.check_if_triplet_is_a_polytomy(tree))
 
     def test_legacy_triplet_pass_aggregates_supported_relationship(self):
         groups = {"test": [["A"], ["B"], ["C"]]}

--- a/tests/unit/services/tree/test_quartet_network.py
+++ b/tests/unit/services/tree/test_quartet_network.py
@@ -366,6 +366,12 @@ class TestTreeTest:
         monkeypatch.setattr(builtins, "sorted", original_sorted)
         assert abs(p - 0.0418) < 0.005
 
+    @pytest.mark.parametrize("counts", [[20, 45, 35], [20, 35, 45]])
+    def test_tree_test_is_invariant_to_dominant_topology(self, counts):
+        assert QuartetNetwork._tree_test(counts) == pytest.approx(
+            QuartetNetwork._tree_test([45, 35, 20])
+        )
+
 
 class TestClassifyQuartet:
     def test_tree_like(self):
@@ -479,6 +485,32 @@ class TestNanuqDistance:
         assert QuartetNetwork._top_two_topology_indices([4, 5, 5]) == (1, 2)
         assert QuartetNetwork._top_two_topology_indices([3, 5, 4]) == (1, 2)
 
+    @pytest.mark.parametrize(
+        ("topology", "expected"),
+        [
+            (0, [(0, 2), (0, 3), (1, 2), (1, 3)]),
+            (1, [(0, 1), (0, 3), (2, 1), (2, 3)]),
+            (2, [(0, 1), (0, 2), (3, 1), (3, 2)]),
+        ],
+    )
+    def test_cross_pair_helper_supports_every_topology(self, topology, expected):
+        assert QuartetNetwork._cross_pairs(topology, 0, 1, 2, 3) == expected
+
+    @pytest.mark.parametrize(
+        ("counts", "dominant", "top_two"),
+        [
+            ([0, 1, 2], 2, (2, 1)),
+            ([2, 1, 3], 2, (2, 0)),
+            ([2, 3, 1], 1, (1, 0)),
+            ([1, 2, 3], 2, (2, 1)),
+        ],
+    )
+    def test_topology_index_helpers_cover_strict_orderings(
+        self, counts, dominant, top_two
+    ):
+        assert QuartetNetwork._dominant_topology_index(counts) == dominant
+        assert QuartetNetwork._top_two_topology_indices(counts) == top_two
+
     def test_tree_quartet_adds_cross_pairs(self):
         """Tree-like quartet ab|cd should add 1 to cross-split pairs only."""
         all_taxa = frozenset({"A", "B", "C", "D"})
@@ -503,6 +535,35 @@ class TestNanuqDistance:
         # Same-side pairs (A,B), (C,D) stay 0
         assert dist[ia][ib] == 0.0
         assert dist[ic][id_] == 0.0
+
+    @pytest.mark.parametrize(
+        ("counts", "expected_pairs"),
+        [
+            ([0, 5, 0], {("A", "B"), ("A", "D"), ("B", "C"), ("C", "D")}),
+            ([0, 0, 5], {("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")}),
+        ],
+    )
+    def test_tree_quartet_supports_other_dominant_topologies(
+        self, counts, expected_pairs
+    ):
+        all_taxa = frozenset({"A", "B", "C", "D"})
+        quartet_results = {
+            ("A", "B", "C", "D"): {
+                "classification": "tree",
+                "counts": counts,
+            }
+        }
+
+        taxa, dist, idx = QuartetNetwork._compute_nanuq_distance(
+            all_taxa, quartet_results
+        )
+        observed_pairs = {
+            (first, second)
+            for first, second in itertools.combinations(taxa, 2)
+            if dist[idx[first]][idx[second]] == 1.0
+        }
+
+        assert observed_pairs == expected_pairs
 
     def test_star_quartet_adds_all_pairs(self):
         """Unresolved quartet should add 1 to all 6 pairwise distances."""
@@ -820,6 +881,23 @@ class TestBuildSplitsGraph:
         assert split in directions
         assert split.iterations == 1
 
+    def test_circular_gap_positions_rejects_no_boundary_split(self):
+        ordering = ["A", "B", "C", "D"]
+
+        assert QuartetNetwork._circular_gap_positions(frozenset(ordering), ordering) is None
+
+    def test_compute_split_directions_handles_degenerate_gap_pair(self):
+        ordering = ["A", "B", "C", "D"]
+        split = frozenset({"A"})
+
+        directions = QuartetNetwork._compute_split_directions(
+            ordering,
+            [(split, 1, 1.0)],
+            {split: (0, 0)},
+        )
+
+        assert directions[split] == (1.0, 0.0)
+
     @staticmethod
     def _legacy_build_splits_graph(circular_splits, all_taxa):
         splits_list = [s[0] for s in circular_splits]
@@ -899,6 +977,39 @@ class TestBuildSplitsGraph:
         assert self._canonical_edges(observed[2]) == self._canonical_edges(expected[2])
         assert observed[3] == expected[3]
         assert observed[4] == expected[4]
+
+    def test_build_splits_graph_handles_no_splits(self):
+        assert QuartetNetwork._build_splits_graph([], frozenset({"A", "B"})) == (
+            {},
+            set(),
+            [],
+            [],
+            [],
+        )
+
+    @pytest.mark.parametrize(
+        "split_sets",
+        [
+            [{"A"}, {"A", "B"}],
+            [{"A", "B"}, {"A"}],
+            [{"A", "B"}, {"C", "D"}],
+        ],
+    )
+    def test_build_splits_graph_supports_nested_and_complementary_splits(
+        self, split_sets
+    ):
+        all_taxa = frozenset({"A", "B", "C", "D"})
+        circular_splits = [
+            (frozenset(split), 1, 1.0)
+            for split in split_sets
+        ]
+
+        observed = QuartetNetwork._build_splits_graph(circular_splits, all_taxa)
+        expected = self._legacy_build_splits_graph(circular_splits, all_taxa)
+
+        assert observed[0] == expected[0]
+        assert observed[1] == expected[1]
+        assert self._canonical_edges(observed[2]) == self._canonical_edges(expected[2])
 
 
 class TestNetworkPlot:

--- a/tests/unit/services/tree/test_quartet_network.py
+++ b/tests/unit/services/tree/test_quartet_network.py
@@ -33,6 +33,7 @@ def test_position_extent_scans_positions_once():
     assert _position_extent(positions) == 5.0
     assert positions.iterations == 1
     assert _position_extent([]) == 0
+    assert _position_extent([(0.0, -3.0), (1.0, 3.0)]) == 6.0
 
 
 def _write(path, content):
@@ -103,6 +104,29 @@ def test_shared_tip_set_stops_when_empty():
     assert quartet_network_module._shared_tip_set(
         [{"A", "B"}, {"C", "D"}, FailIfScanned({"A"})]
     ) == set()
+
+
+def test_all_tip_sets_identical_accepts_empty_input():
+    assert quartet_network_module._all_tip_sets_identical([]) is True
+
+
+def test_chi_squared_survival_function_supports_other_degrees_of_freedom():
+    from scipy.stats import chi2
+
+    assert quartet_network_module._chi2_sf(4.5, 3) == pytest.approx(
+        chi2.sf(4.5, 3)
+    )
+
+
+def test_lazy_json_output_delegates_to_helper(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "phykit.helpers.json_output.print_json",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or "printed",
+    )
+
+    assert quartet_network_module.print_json({"result": 1}, indent=2) == "printed"
+    assert calls == [(({"result": 1},), {"indent": 2})]
 
 
 def test_lazy_phylo_caches_resolved_read(monkeypatch):
@@ -181,6 +205,65 @@ class TestExtractBipartitions:
         assert frozenset({"A", "B"}) in all_sides
         assert frozenset({"C", "D"}) in all_sides
         assert frozenset({"E", "F"}) in all_sides
+
+    def test_extract_bipartitions_supports_legacy_tree_interface(self):
+        parsed = _make_tree("((A,B),(C,D));")
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return parsed.find_clades(*args, **kwargs)
+
+            def get_nonterminals(self):
+                return parsed.get_nonterminals()
+
+        observed = QuartetNetwork._extract_bipartitions(
+            LegacyTree(),
+            frozenset({"A", "B", "C", "D"}),
+        )
+
+        assert any(side == {"A", "B"} for side, _complement in observed)
+
+    def test_direct_bipartition_extraction_rejects_unsupported_objects(self):
+        assert QuartetNetwork._extract_bipartitions_direct(
+            object(), frozenset({"A", "B", "C", "D"})
+        ) is None
+
+        malformed = Namespace(root=Namespace(clades=[object()]))
+        assert QuartetNetwork._extract_bipartitions_direct(
+            malformed, frozenset({"A", "B", "C", "D"})
+        ) is None
+
+    def test_direct_bipartition_extraction_handles_unary_clades(self):
+        tree = _make_tree("(((A),B),(C,D));")
+
+        observed = QuartetNetwork._extract_bipartitions_direct(
+            tree,
+            frozenset({"A", "B", "C", "D"}),
+        )
+
+        assert observed is not None
+        assert any(side == {"A", "B"} for side, _complement in observed)
+
+    def test_postorder_direct_rejects_unsupported_objects(self):
+        assert QuartetNetwork._postorder_clades_direct(object()) is None
+        malformed = Namespace(root=Namespace(clades=[object()]))
+        assert QuartetNetwork._postorder_clades_direct(malformed) is None
+
+    def test_mask_extraction_falls_back_to_tree_postorder(self, monkeypatch):
+        tree = _make_tree("((A,B),(C,D));")
+        monkeypatch.setattr(
+            QuartetNetwork,
+            "_postorder_clades_direct",
+            staticmethod(lambda _tree: None),
+        )
+
+        masks = QuartetNetwork._extract_bipartition_masks(
+            tree,
+            frozenset({"A", "B", "C", "D"}),
+            {"A": 0, "B": 1, "C": 2, "D": 3},
+        )
+
+        assert masks
 
 
 class TestDetermineQuartetTopology:
@@ -1157,8 +1240,133 @@ class TestPruneToTaxa:
         assert [tip.name for tip in tree.get_terminals()] == ["B", "D"]
         assert [tip.branch_length for tip in tree.get_terminals()] == [5.0, 11.0]
 
+    def test_tip_collection_falls_back_to_public_tree_api(self, monkeypatch):
+        tree = Namespace(
+            get_terminals=lambda: [Namespace(name="A"), Namespace(name="B")]
+        )
+        monkeypatch.setattr(
+            quartet_network_module.Tree,
+            "calculate_terminal_names_fast",
+            staticmethod(lambda _tree: None),
+        )
+
+        assert QuartetNetwork._tips(tree) == {"A", "B"}
+
+    def test_pruning_falls_back_to_individual_public_calls(self, monkeypatch):
+        class LegacyTree:
+            def __init__(self):
+                self.terminals = [Namespace(name=name) for name in "ABCD"]
+
+            def get_terminals(self):
+                return list(self.terminals)
+
+            def prune(self, terminal):
+                self.terminals.remove(terminal)
+
+        tree = LegacyTree()
+        monkeypatch.setattr(
+            quartet_network_module.Tree,
+            "calculate_terminal_clades_fast",
+            staticmethod(lambda _tree: None),
+        )
+        monkeypatch.setattr(
+            quartet_network_module.Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            staticmethod(lambda _tree, _target_ids: False),
+        )
+
+        observed = QuartetNetwork._prune_to_taxa(tree, {"A", "C"})
+
+        assert observed is tree
+        assert [terminal.name for terminal in tree.terminals] == ["A", "C"]
+
+    def test_shared_taxa_mode_requires_four_shared_taxa(self):
+        svc = QuartetNetwork(
+            Namespace(
+                trees="unused",
+                alpha=0.05,
+                beta=0.95,
+                missing_taxa="shared",
+                plot_output=None,
+                json=False,
+            )
+        )
+        trees = [
+            _make_tree("((A,B),(C,D));"),
+            _make_tree("((A,B),(C,E));"),
+        ]
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._normalize_taxa(trees)
+
+        assert exc_info.value.messages == [
+            "Unable to compute quartet network after pruning to shared taxa.",
+            "At least 4 shared taxa are required.",
+        ]
+
 
 class TestQuartetNetworkRun:
+    @staticmethod
+    def _make_service(trees, missing_taxa="error"):
+        return QuartetNetwork(
+            Namespace(
+                trees=str(trees),
+                alpha=0.05,
+                beta=0.95,
+                missing_taxa=missing_taxa,
+                plot_output=None,
+                json=False,
+            )
+        )
+
+    def test_parse_trees_reports_missing_source(self, tmp_path):
+        missing = tmp_path / "missing-trees.nwk"
+        svc = self._make_service(missing)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(missing))
+
+        assert exc_info.value.messages[0] == (
+            f"{missing} corresponds to no such file or directory."
+        )
+
+    def test_parse_trees_rejects_empty_source(self, tmp_path):
+        tree_file = tmp_path / "empty.nwk"
+        _write(tree_file, "\n# comment only\n")
+        svc = self._make_service(tree_file)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert exc_info.value.messages == ["No trees found in input."]
+
+    def test_parse_trees_wraps_inline_newick_errors(self, tmp_path, monkeypatch):
+        tree_file = tmp_path / "trees.nwk"
+        _write(tree_file, "((A,B),(C,D));\n")
+        svc = self._make_service(tree_file)
+        monkeypatch.setattr(
+            quartet_network_module.Phylo,
+            "read",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("invalid")),
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert exc_info.value.messages == ["Failed to parse Newick trees: invalid"]
+
+    def test_parse_tree_list_reports_missing_entry(self, tmp_path):
+        tree_list = tmp_path / "tree-list.txt"
+        _write(tree_list, "missing-tree.nwk\n")
+        svc = self._make_service(tree_list)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_list))
+
+        assert exc_info.value.messages[0] == (
+            f"{tmp_path / 'missing-tree.nwk'} corresponds to no such file or directory."
+        )
+
     def test_parse_trees_skips_comments_and_blank_lines(self, tmp_path):
         tree_file = tmp_path / "trees.nwk"
         _write(

--- a/tests/unit/services/tree/test_rate_heterogeneity.py
+++ b/tests/unit/services/tree/test_rate_heterogeneity.py
@@ -1,6 +1,7 @@
 import builtins
 import importlib
 import json
+import math
 import os
 import subprocess
 import sys
@@ -426,6 +427,32 @@ class TestRegimeParsing:
             "At least 3 shared taxa are required.",
         ]
 
+    @pytest.mark.parametrize(
+        ("tree_tips", "rows", "expected_warning"),
+        [
+            (
+                ["A", "B", "C", "D"],
+                "A\tr1\nB\tr1\nC\tr2\n",
+                "taxa in tree but not in regime file: D",
+            ),
+            (
+                ["A", "B", "C"],
+                "A\tr1\nB\tr1\nC\tr2\nD\tr2\n",
+                "taxa in regime file but not in tree: D",
+            ),
+        ],
+    )
+    def test_one_sided_regime_mismatches_warn(
+        self, service, tmp_path, capsys, tree_tips, rows, expected_warning
+    ):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text(rows)
+
+        regimes = service._parse_regime_file(str(regime_file), tree_tips)
+
+        assert set(regimes) == {"A", "B", "C"}
+        assert expected_warning in capsys.readouterr().err
+
 
 class TestTraitParsing:
     def test_comments_and_blanks(self, service, tmp_path):
@@ -571,6 +598,32 @@ class TestTraitParsing:
             "Only 2 shared taxa between tree and trait file.",
             "At least 3 shared taxa are required.",
         ]
+
+    @pytest.mark.parametrize(
+        ("tree_tips", "rows", "expected_warning"),
+        [
+            (
+                ["A", "B", "C", "D"],
+                "A\t1\nB\t2\nC\t3\n",
+                "taxa in tree but not in trait file: D",
+            ),
+            (
+                ["A", "B", "C"],
+                "A\t1\nB\t2\nC\t3\nD\t4\n",
+                "taxa in trait file but not in tree: D",
+            ),
+        ],
+    )
+    def test_one_sided_trait_mismatches_warn(
+        self, service, tmp_path, capsys, tree_tips, rows, expected_warning
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text(rows)
+
+        traits = service._parse_trait_file(str(trait_file), tree_tips)
+
+        assert set(traits) == {"A", "B", "C"}
+        assert expected_warning in capsys.readouterr().err
 
 
 class TestFitchParsimony:
@@ -747,6 +800,68 @@ class TestFitchParsimony:
             if clade != tree.root:
                 assert id(clade) in branch_regimes
                 assert branch_regimes[id(clade)] in {"aquatic", "terrestrial"}
+
+    @pytest.mark.parametrize("assigned_tip", ["A", "B"])
+    def test_branch_regimes_handle_one_sided_and_missing_states(
+        self, service, assigned_tip
+    ):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        parent_map = service._build_parent_map(tree)
+
+        branch_regimes = service._assign_branch_regimes(
+            tree,
+            {assigned_tip: "known"},
+            parent_map,
+        )
+
+        assert branch_regimes[id(tree.root.clades[0])] == "known"
+        assert branch_regimes[id(tree.root.clades[1])] == "known"
+        assert branch_regimes[id(tree.root.clades[1].clades[0])] == "known"
+
+    def test_branch_regimes_fall_back_when_postorder_states_are_unavailable(
+        self, service
+    ):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        preorder = list(service._iter_preorder(tree.root))
+        parent_map = service._build_parent_map(tree, preorder)
+
+        branch_regimes = service._assign_branch_regimes(
+            tree,
+            {"A": "fallback"},
+            parent_map,
+            preorder_clades=preorder,
+            postorder_clades=[],
+        )
+
+        assert set(branch_regimes.values()) == {"fallback"}
+
+    def test_branch_regimes_resolve_state_without_parent_context(self, service):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        tip = tree.root.clades[0]
+
+        branch_regimes = service._assign_branch_regimes(
+            tree,
+            {"A": "direct"},
+            {},
+            preorder_clades=[tree.root, tip],
+            postorder_clades=[tip, tree.root],
+        )
+
+        assert branch_regimes[id(tip)] == "direct"
+
+    def test_branch_regimes_mark_parentless_missing_state_unknown(self, service):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        missing_tip = tree.root.clades[1]
+
+        branch_regimes = service._assign_branch_regimes(
+            tree,
+            {"A": "known"},
+            {},
+            preorder_clades=[tree.root, missing_tip],
+            postorder_clades=[],
+        )
+
+        assert branch_regimes[id(missing_tip)] == "unknown"
 
 
 class TestPerRegimeVCV:
@@ -1000,6 +1115,50 @@ class TestSingleRate:
         assert calls == 1
         np.testing.assert_allclose(fast, inverse)
 
+    def test_fit_single_rate_falls_back_to_inverse(self, service, monkeypatch):
+        expected = (1.5, 2.5, -3.5)
+        monkeypatch.setattr(
+            service,
+            "_fit_single_rate_cholesky",
+            lambda *_args: (_ for _ in ()).throw(ValueError("not SPD")),
+        )
+        monkeypatch.setattr(
+            service,
+            "_fit_single_rate_inverse",
+            lambda *_args: expected,
+        )
+
+        assert service._fit_single_rate(np.ones(2), np.eye(2)) == expected
+
+    def test_cholesky_fit_rejects_zero_rate(self, service):
+        sigma2, ancestral, likelihood = service._fit_single_rate_cholesky(
+            np.ones(3),
+            np.eye(3),
+        )
+
+        assert sigma2 == pytest.approx(0.0)
+        assert ancestral == pytest.approx(1.0)
+        assert likelihood == -np.inf
+
+    def test_inverse_fit_reports_singular_covariance(self, service):
+        with pytest.raises(PhykitUserError) as exc_info:
+            service._fit_single_rate_inverse(
+                np.array([1.0, 2.0]),
+                np.zeros((2, 2)),
+            )
+
+        assert exc_info.value.messages[0] == "Singular VCV matrix: cannot invert."
+
+    def test_inverse_fit_rejects_zero_rate(self, service):
+        sigma2, ancestral, likelihood = service._fit_single_rate_inverse(
+            np.ones(3),
+            np.eye(3),
+        )
+
+        assert sigma2 == pytest.approx(0.0)
+        assert ancestral == pytest.approx(1.0)
+        assert likelihood == -np.inf
+
 
 class TestMultiRate:
     def test_log_likelihood_geq_single(self, service):
@@ -1109,8 +1268,155 @@ class TestMultiRate:
         assert calls == 1
         np.testing.assert_allclose(fast, inverse)
 
+    def test_multi_rate_likelihood_falls_back_for_singular_covariance(self, service):
+        ancestral, likelihood = service._multi_rate_log_likelihood(
+            np.array([1.0, 2.0]),
+            np.zeros((2, 2)),
+            np.ones(2),
+        )
+
+        assert ancestral == 0.0
+        assert likelihood == -np.inf
+
+    def test_cholesky_likelihood_rejects_zero_precision_sum(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setattr(
+            rate_heterogeneity_module,
+            "cho_factor",
+            lambda matrix, **_kwargs: (matrix, True),
+        )
+        monkeypatch.setattr(
+            rate_heterogeneity_module,
+            "cho_solve",
+            lambda *_args, **_kwargs: np.zeros((2, 2)),
+        )
+
+        assert service._multi_rate_log_likelihood_cholesky(
+            np.array([1.0, 2.0]),
+            np.eye(2),
+            np.ones(2),
+        ) == (0.0, -np.inf)
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [
+            pytest.param(np.zeros((2, 2)), id="singular"),
+            pytest.param(np.diag([1.0, -1.0]), id="zero-denominator"),
+            pytest.param(
+                np.diag([1.0, -2.0]),
+                id="non-positive-determinant",
+            ),
+        ],
+    )
+    def test_inverse_likelihood_rejects_invalid_covariance(
+        self, service, matrix
+    ):
+        ancestral, likelihood = service._multi_rate_log_likelihood_inverse(
+            np.array([1.0, 2.0]),
+            matrix,
+            np.ones(2),
+        )
+
+        assert ancestral == 0.0
+        assert likelihood == -np.inf
+
+    def test_multi_rate_fit_tolerates_failed_optimizers(self, service, monkeypatch):
+        monkeypatch.setattr(
+            rate_heterogeneity_module,
+            "minimize",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("failed")),
+        )
+        monkeypatch.setattr(
+            service,
+            "_multi_rate_log_likelihood",
+            lambda *_args: (1.5, -2.5),
+        )
+        matrices = {"r1": np.eye(2), "r2": np.eye(2)}
+
+        sigma2, ancestral, likelihood = service._fit_multi_rate(
+            np.array([1.0, 2.0]),
+            matrices,
+            ["r1", "r2"],
+        )
+
+        np.testing.assert_array_equal(sigma2, np.ones(2))
+        assert ancestral == 1.5
+        assert likelihood == -2.5
+
+    def test_multi_rate_fit_rejects_non_finite_final_likelihood(
+        self, service, monkeypatch
+    ):
+        def penalized_minimize(function, x0, **_kwargs):
+            assert function(x0) == 1e20
+            return Namespace(fun=1.0, x=x0)
+
+        monkeypatch.setattr(
+            rate_heterogeneity_module,
+            "minimize",
+            penalized_minimize,
+        )
+        monkeypatch.setattr(
+            service,
+            "_multi_rate_log_likelihood",
+            lambda *_args: (0.0, -np.inf),
+        )
+
+        sigma2, ancestral, likelihood = service._fit_multi_rate(
+            np.array([1.0, 2.0]),
+            {"r1": np.eye(2), "r2": np.eye(2)},
+            ["r1", "r2"],
+        )
+
+        assert np.all(sigma2 > 0)
+        assert ancestral == 0.0
+        assert likelihood == -np.inf
+
 
 class TestLRT:
+    def test_bootstrap_returns_one_for_non_positive_null_rate(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setattr(
+            service,
+            "_fit_single_rate",
+            lambda *_args: (0.0, 1.0, -1.0),
+        )
+
+        assert service._parametric_bootstrap(
+            np.array([1.0, 2.0]),
+            np.eye(2),
+            {"r1": np.eye(2), "r2": np.eye(2)},
+            ["r1", "r2"],
+            observed_lrt=1.0,
+            n_sim=3,
+            seed=1,
+        ) == (1.0, 3)
+
+    def test_bootstrap_adds_jitter_to_singular_covariance(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setattr(
+            service,
+            "_fit_single_rate",
+            lambda *_args: (1.0, 0.0, 0.0),
+        )
+        monkeypatch.setattr(
+            service,
+            "_fit_multi_rate",
+            lambda *_args: (np.ones(2), 0.0, 0.0),
+        )
+
+        assert service._parametric_bootstrap(
+            np.array([1.0, 2.0]),
+            np.zeros((2, 2)),
+            {"r1": np.zeros((2, 2)), "r2": np.zeros((2, 2))},
+            ["r1", "r2"],
+            observed_lrt=0.0,
+            n_sim=1,
+            seed=1,
+        ) == (1.0, 1)
+
     def test_chi2_p_in_range(self, service):
         tree = service.read_tree_file()
         tree_tips = service.get_tip_names_from_tree(tree)
@@ -1286,6 +1592,71 @@ class TestRun:
         assert exc_info.value.messages == [
             "At least 2 distinct regimes are required."
         ]
+
+    def test_json_plot_run_handles_zero_single_rate(
+        self, default_args, tmp_path, monkeypatch
+    ):
+        default_args.json = True
+        default_args.plot = str(tmp_path / "regimes.png")
+        service = RateHeterogeneity(default_args)
+        tree = service.read_tree_file()
+        trait_values = {"A": 1.0, "B": 1.0, "C": 1.0}
+        regime_assignments = {"A": "r1", "B": "r1", "C": "r2"}
+        captured = {}
+        monkeypatch.setattr(service, "read_tree_file_unmodified", lambda: tree)
+        monkeypatch.setattr(
+            service,
+            "_parse_trait_file",
+            lambda *_args: trait_values,
+        )
+        monkeypatch.setattr(
+            service,
+            "_parse_regime_file",
+            lambda *_args: regime_assignments,
+        )
+        monkeypatch.setattr(
+            service,
+            "_prepare_shared_trait_regime_data",
+            lambda *_args: (
+                trait_values,
+                regime_assignments,
+                [],
+                ["A", "B", "C"],
+                ["r1", "r2"],
+            ),
+        )
+        monkeypatch.setattr(service, "_assign_branch_regimes", lambda *_args: {})
+        monkeypatch.setattr(
+            service,
+            "_build_per_regime_vcv",
+            lambda *_args: {"r1": np.eye(3), "r2": np.eye(3)},
+        )
+        monkeypatch.setattr(
+            service,
+            "_fit_single_rate",
+            lambda *_args: (0.0, 1.0, -2.0),
+        )
+        monkeypatch.setattr(
+            service,
+            "_fit_multi_rate",
+            lambda *_args: (np.array([1.0, 2.0]), 1.0, -1.5),
+        )
+        monkeypatch.setattr(
+            service,
+            "_plot_regime_tree",
+            lambda *args: captured.setdefault("plot_args", args),
+        )
+        monkeypatch.setattr(
+            rate_heterogeneity_module,
+            "print_json",
+            lambda result: captured.setdefault("result", result),
+        )
+
+        service.run()
+
+        assert captured["plot_args"][-1] == default_args.plot
+        assert captured["result"]["plot_output"] == default_args.plot
+        assert math.isnan(captured["result"]["r_squared_regime"])
 
     @patch("builtins.print")
     def test_text_output(self, mocked_print, default_args):

--- a/tests/unit/services/tree/test_rate_heterogeneity.py
+++ b/tests/unit/services/tree/test_rate_heterogeneity.py
@@ -63,6 +63,29 @@ def test_lazy_numpy_caches_resolved_attributes():
     assert lazy_np._module is not None
 
 
+def test_lazy_json_output_delegates_to_helper(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "phykit.helpers.json_output.print_json",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or "printed",
+    )
+
+    assert rate_heterogeneity_module.print_json({"result": 1}, indent=2) == "printed"
+    assert calls == [(({"result": 1},), {"indent": 2})]
+
+
+def test_chi_squared_survival_function_supports_other_degrees_of_freedom():
+    from scipy.stats import chi2
+
+    assert rate_heterogeneity_module._chi2_sf(4.5, 3) == pytest.approx(
+        chi2.sf(4.5, df=3)
+    )
+
+
+def test_empty_per_regime_vcv_sum_returns_zero():
+    assert RateHeterogeneity._sum_vcv_matrices({}) == 0
+
+
 def test_merge_nonempty_child_state_sets_does_not_slice_children():
     class NoSliceList(list):
         def __getitem__(self, key):
@@ -374,6 +397,35 @@ class TestRegimeParsing:
         assert "1 taxa in tree but not in regime file: dog" in stderr
         assert "1 taxa in regime file but not in tree: off_tree" in stderr
 
+    def test_unordered_exact_taxa_return_without_warnings(
+        self, service, tmp_path, capsys
+    ):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text("C\tr1\nA\tr1\nB\tr2\n")
+
+        regimes = service._parse_regime_file(
+            str(regime_file),
+            ["A", "B", "C"],
+        )
+
+        assert regimes == {"C": "r1", "A": "r1", "B": "r2"}
+        assert capsys.readouterr().err == ""
+
+    def test_fewer_than_three_shared_regime_taxa_errors(self, service, tmp_path):
+        regime_file = tmp_path / "regimes.tsv"
+        regime_file.write_text("A\tr1\nB\tr2\nX\tr1\n")
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            service._parse_regime_file(
+                str(regime_file),
+                ["A", "B", "C"],
+            )
+
+        assert exc_info.value.messages == [
+            "Only 2 shared taxa between tree and regime file.",
+            "At least 3 shared taxa are required.",
+        ]
+
 
 class TestTraitParsing:
     def test_comments_and_blanks(self, service, tmp_path):
@@ -463,6 +515,62 @@ class TestTraitParsing:
             "Non-numeric trait value 'bad' for taxon 'bear' on line 2."
             in exc_info.value.messages
         )
+
+    def test_missing_file(self, service):
+        with pytest.raises(PhykitUserError) as exc_info:
+            service._parse_trait_file(
+                "/nonexistent/traits.tsv",
+                ["A", "B", "C"],
+            )
+
+        assert exc_info.value.messages[0] == (
+            "/nonexistent/traits.tsv corresponds to no such file or directory."
+        )
+
+    def test_unordered_exact_taxa_return_without_warnings(
+        self, service, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("C\t3.0\nA\t1.0\nB\t2.0\n")
+
+        traits = service._parse_trait_file(
+            str(trait_file),
+            ["A", "B", "C"],
+        )
+
+        assert traits == {"C": 3.0, "A": 1.0, "B": 2.0}
+        assert capsys.readouterr().err == ""
+
+    def test_mismatched_taxa_warn_and_return_shared_values(
+        self, service, tmp_path, capsys
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nC\t3.0\nE\t5.0\n")
+
+        traits = service._parse_trait_file(
+            str(trait_file),
+            ["A", "B", "C", "D"],
+        )
+
+        assert traits == {"A": 1.0, "B": 2.0, "C": 3.0}
+        stderr = capsys.readouterr().err
+        assert "1 taxa in tree but not in trait file: D" in stderr
+        assert "1 taxa in trait file but not in tree: E" in stderr
+
+    def test_fewer_than_three_shared_trait_taxa_errors(self, service, tmp_path):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text("A\t1.0\nB\t2.0\nX\t3.0\n")
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            service._parse_trait_file(
+                str(trait_file),
+                ["A", "B", "C"],
+            )
+
+        assert exc_info.value.messages == [
+            "Only 2 shared taxa between tree and trait file.",
+            "At least 3 shared taxa are required.",
+        ]
 
 
 class TestFitchParsimony:
@@ -1118,6 +1226,67 @@ class TestRValidation:
 
 
 class TestRun:
+    def test_exact_shared_data_requires_three_taxa(self):
+        with pytest.raises(PhykitUserError) as exc_info:
+            RateHeterogeneity._prepare_shared_trait_regime_data(
+                ["A", "B"],
+                {"A": 1.0, "B": 2.0},
+                {"A": "r1", "B": "r2"},
+            )
+
+        assert exc_info.value.messages == [
+            "Only 2 shared taxa among tree, trait, and regime files.",
+            "At least 3 shared taxa are required.",
+        ]
+
+    def test_partially_overlapping_data_requires_three_shared_taxa(self):
+        with pytest.raises(PhykitUserError) as exc_info:
+            RateHeterogeneity._prepare_shared_trait_regime_data(
+                ["A", "B", "C"],
+                {"A": 1.0, "B": 2.0, "C": 3.0},
+                {"A": "r1", "B": "r2", "D": "r1"},
+            )
+
+        assert exc_info.value.messages == [
+            "Only 2 shared taxa among tree, trait, and regime files.",
+            "At least 3 shared taxa are required.",
+        ]
+
+    def test_equal_taxa_in_different_orders_reuse_input_mappings(self):
+        trait_values = {"A": 1.0, "B": 2.0, "C": 3.0}
+        regime_assignments = {"C": "r1", "B": "r2", "A": "r1"}
+
+        observed = RateHeterogeneity._prepare_shared_trait_regime_data(
+            ["A", "B", "C"],
+            trait_values,
+            regime_assignments,
+        )
+
+        assert observed[0] is trait_values
+        assert observed[1] is regime_assignments
+        assert observed[2] == []
+        assert observed[3] == ["A", "B", "C"]
+        assert observed[4] == ["r1", "r2"]
+
+    def test_run_requires_two_distinct_regimes(self, default_args, tmp_path):
+        regime_file = tmp_path / "one-regime.tsv"
+        tree = RateHeterogeneity(default_args).read_tree_file()
+        regime_file.write_text(
+            "".join(
+                f"{tip.name}\tshared\n"
+                for tip in tree.get_terminals()
+            )
+        )
+        default_args.regime_data = str(regime_file)
+        service = RateHeterogeneity(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            service.run()
+
+        assert exc_info.value.messages == [
+            "At least 2 distinct regimes are required."
+        ]
+
     @patch("builtins.print")
     def test_text_output(self, mocked_print, default_args):
         svc = RateHeterogeneity(default_args)
@@ -1933,10 +2102,7 @@ class TestPlot:
         assert output_path.stat().st_size > 0
 
     def test_plot_file_created(self, default_args):
-        try:
-            import matplotlib
-        except ImportError:
-            pytest.skip("matplotlib not installed")
+        pytest.importorskip("matplotlib")
 
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             tmppath = f.name
@@ -1952,10 +2118,7 @@ class TestPlot:
                 os.unlink(tmppath)
 
     def test_plot_circular(self):
-        try:
-            import matplotlib
-        except ImportError:
-            pytest.skip("matplotlib not installed")
+        pytest.importorskip("matplotlib")
 
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             tmppath = f.name

--- a/tests/unit/services/tree/test_stochastic_character_map.py
+++ b/tests/unit/services/tree/test_stochastic_character_map.py
@@ -95,6 +95,17 @@ def json_args():
 
 
 class TestProcessArgs:
+    def test_print_json_wrapper_delegates(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "phykit.helpers.json_output.print_json",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        scm_module.print_json({"value": 1}, indent=2)
+
+        assert calls == [(({"value": 1},), {"indent": 2})]
+
     def test_defaults(self):
         args = Namespace(
             tree="t.tre",
@@ -183,6 +194,20 @@ class TestDiscreteTraitParsing:
 
 
 class TestTreePruning:
+    def test_missing_tip_count_rejects_legacy_and_malformed_trees(self):
+        assert StochasticCharacterMap._count_missing_tip_states(object(), {}) is None
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        assert (
+            StochasticCharacterMap._count_missing_tip_states(MalformedTree(), {})
+            is None
+        )
+
     def test_count_missing_tip_states_uses_direct_traversal(self, monkeypatch):
         tree = Phylo.read(
             StringIO("((A:1,B:1):1,(C:1,D:1):1);"),
@@ -264,8 +289,134 @@ class TestTreePruning:
         assert removed == 1
         assert {tip.name for tip in tree.get_terminals()} == {"A"}
 
+    def test_prune_tree_to_tip_states_uses_per_tip_standard_fallback(
+        self, monkeypatch
+    ):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        monkeypatch.setattr(
+            scm_module.Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            staticmethod(lambda *_args: False),
+        )
+
+        removed = StochasticCharacterMap._prune_tree_to_tip_states(
+            tree, {"A": "x", "B": "y"}
+        )
+
+        assert removed == 1
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "B"}
+
+    def test_prune_tree_to_tip_states_supports_legacy_tree(self):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class LegacyTree:
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B"), Tip("C")]
+
+            def get_terminals(self):
+                return self.tips
+
+            def prune(self, tip):
+                self.tips.remove(tip)
+
+        tree = LegacyTree()
+
+        removed = StochasticCharacterMap._prune_tree_to_tip_states(
+            tree, {"A": "x", "B": "y"}
+        )
+
+        assert removed == 1
+        assert [tip.name for tip in tree.get_terminals()] == ["A", "B"]
+
+    def test_prune_tree_to_tip_states_recovers_from_malformed_root(self):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B"), Tip("C")]
+
+            def get_terminals(self):
+                return self.tips
+
+            def prune(self, tip):
+                self.tips.remove(tip)
+
+        tree = MalformedTree()
+
+        removed = StochasticCharacterMap._prune_tree_to_tip_states(
+            tree, {"A": "x", "B": "y"}
+        )
+
+        assert removed == 1
+        assert [tip.name for tip in tree.get_terminals()] == ["A", "B"]
+
 
 class TestTraversalHelpers:
+    def test_build_parent_map_supports_legacy_and_malformed_trees(
+        self, default_args
+    ):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+
+        class LegacyTree:
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        legacy_map = svc._build_parent_map(LegacyTree())
+        assert len(legacy_map) == len(list(tree.find_clades())) - 1
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree(LegacyTree):
+            root = MalformedRoot()
+
+        malformed_map = svc._build_parent_map(MalformedTree())
+        assert len(malformed_map) == len(list(tree.find_clades())) - 1
+
+    def test_get_parent_supports_lookup_map_and_generic_traversal(self, default_args):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        tip = tree.find_any(name="A")
+        parent_map = svc._build_parent_map(tree)
+
+        assert svc._get_parent(tree, tip, parent_map) is parent_map[id(tip)]
+        assert svc._get_parent(tree, tip) is parent_map[id(tip)]
+        assert svc._get_parent(tree, object()) is None
+
+    def test_build_simulation_metadata_uses_generic_tree_fallback(self, default_args):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        parent_map = svc._build_parent_map(tree)
+        simulation_nodes, branch_nodes = svc._build_simulation_metadata(
+            MalformedTree(),
+            {"A": "x", "B": "y", "C": "x"},
+            ["x", "y"],
+            parent_map,
+        )
+
+        assert len(simulation_nodes) == len(branch_nodes)
+        assert len(simulation_nodes) == len(list(tree.find_clades())) - 1
+
     def test_build_parent_map_uses_direct_traversal(self, default_args, monkeypatch):
         tree = Phylo.read(
             StringIO("((A:1,B:1):1,(C:1,D:1):1);"),
@@ -402,6 +553,28 @@ class TestTraversalHelpers:
 class TestQMatrixFitting:
     """Validated against R 4.4.0 with phytools::fitMk on same tree and traits."""
 
+    def test_shared_discrete_model_wrappers(self, default_args):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        tip_states = {"A": "0", "B": "1", "C": "0"}
+        states = ["0", "1"]
+        Q = svc._build_q_matrix(np.array([0.5]), 2, "ER")
+        pi = np.array([0.5, 0.5])
+
+        transition = svc._matrix_exp(Q, 0.25)
+        conditional, loglik = svc._felsenstein_pruning(
+            tree, tip_states, Q, pi, states
+        )
+        fitted, fitted_loglik = svc._fit_q_matrix(
+            tree, tip_states, states, "ER"
+        )
+
+        assert transition.shape == (2, 2)
+        assert id(tree.root) in conditional
+        assert np.isfinite(loglik)
+        assert fitted.shape == (2, 2)
+        assert np.isfinite(fitted_loglik)
+
     def test_er_model_loglik(self, default_args):
         svc = StochasticCharacterMap(default_args)
         tree = svc.read_tree_file()
@@ -532,6 +705,18 @@ class TestFelsensteinPruning:
 
 
 class TestStochasticMapping:
+    def test_sample_categorical_cdf_clamps_large_state_upper_boundary(self):
+        class UpperBoundaryRng:
+            @staticmethod
+            def random():
+                return 1.0
+
+        observed = StochasticCharacterMap._sample_categorical_cdf(
+            np.linspace(0.1, 1.0, 10), UpperBoundaryRng()
+        )
+
+        assert observed == 9
+
     def test_sample_categorical_matches_numpy_choice_stream(self):
         probs = np.array([0.2, 0.3, 0.5])
         rng_choice = np.random.default_rng(123)

--- a/tests/unit/services/tree/test_stochastic_character_map.py
+++ b/tests/unit/services/tree/test_stochastic_character_map.py
@@ -717,6 +717,112 @@ class TestStochasticMapping:
 
         assert observed == 9
 
+    def test_simulate_branch_history_handles_nonpositive_branch(self, default_args):
+        svc = StochasticCharacterMap(default_args)
+        Q = np.array([[-1.0, 1.0], [1.0, -1.0]])
+
+        assert svc._simulate_branch_history(
+            Q, 0, 1, 0.0, 2, np.random.default_rng(1)
+        ) == [(0.0, 0)]
+
+    def test_simulate_branch_history_fallbacks_after_exhausted_attempts(
+        self, default_args
+    ):
+        svc = StochasticCharacterMap(default_args)
+        Q = np.array([[-1.0, 1.0], [1.0, -1.0]])
+        rng = np.random.default_rng(1)
+
+        assert svc._simulate_branch_history(
+            Q, 0, 0, 2.0, 2, rng, max_attempts=0
+        ) == [(0.0, 0)]
+        assert svc._simulate_branch_history(
+            Q, 0, 1, 2.0, 2, rng, max_attempts=0
+        ) == [(0.0, 0), (1.0, 1)]
+
+    def test_simulate_branch_history_handles_zero_rate_and_missing_transition(
+        self, default_args
+    ):
+        svc = StochasticCharacterMap(default_args)
+
+        zero_rate = svc._simulate_branch_history(
+            np.zeros((2, 2)),
+            0,
+            1,
+            2.0,
+            2,
+            np.random.default_rng(1),
+            max_attempts=1,
+        )
+        missing_transition = svc._simulate_branch_history(
+            np.array([[-1.0, 1.0], [1.0, -1.0]]),
+            0,
+            1,
+            2.0,
+            2,
+            np.random.default_rng(1),
+            max_attempts=1,
+            rates=np.ones(2),
+            transition_cdfs_by_state=[None, None],
+        )
+
+        assert zero_rate == [(0.0, 0), (1.0, 1)]
+        assert missing_transition == [(0.0, 0), (1.0, 1)]
+
+    def test_deterministic_transition_targets_classifies_rows(self):
+        observed = StochasticCharacterMap._deterministic_transition_targets(
+            [
+                None,
+                np.array([0.0, 1.0, 0.0]),
+                np.array([0.5, 0.5, 0.0]),
+            ]
+        )
+
+        assert observed == [-1, 1, -1]
+
+    def test_run_single_simulation_supports_legacy_branch_context(
+        self, default_args, monkeypatch
+    ):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        parent_map = svc._build_parent_map(tree)
+        metadata = svc._build_simulation_metadata(
+            tree,
+            {"A": "x", "B": "y", "C": "x"},
+            ["x", "y"],
+            parent_map,
+        )
+        node_states = {id(clade): 0 for clade in tree.find_clades()}
+        calls = []
+
+        monkeypatch.setattr(
+            svc,
+            "_sample_ancestral_states",
+            lambda *_args, **_kwargs: node_states,
+        )
+
+        def simulate(*_args, **kwargs):
+            calls.append(kwargs["deterministic_next_states"])
+            return [(0.0, 0)]
+
+        monkeypatch.setattr(svc, "_simulate_branch_history", simulate)
+
+        observed = svc._run_single_simulation(
+            tree,
+            {"A": "x", "B": "y", "C": "x"},
+            np.array([[-1.0, 1.0], [1.0, -1.0]]),
+            np.array([0.5, 0.5]),
+            ["x", "y"],
+            np.random.default_rng(1),
+            cond_liks={},
+            parent_map=parent_map,
+            simulation_metadata=metadata,
+            sampling_nodes=[],
+            branch_history_context=(np.ones(2), [None, None]),
+        )
+
+        assert len(observed["branch_histories"]) == len(metadata[1])
+        assert calls and all(value is None for value in calls)
+
     def test_sample_categorical_matches_numpy_choice_stream(self):
         probs = np.array([0.2, 0.3, 0.5])
         rng_choice = np.random.default_rng(123)
@@ -1446,6 +1552,66 @@ class TestStochasticMapping:
 
 
 class TestSummary:
+    def test_summarize_simulations_supports_legacy_tree_traversal(
+        self, default_args
+    ):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        clades = list(tree.find_clades(order="preorder"))
+
+        class LegacyTree:
+            root = object()
+
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        mapping = {
+            "branch_histories": {
+                id(clade): [(0.0, 0)]
+                for clade in clades
+                if clade is not tree.root
+            },
+            "node_states": {id(clade): 0 for clade in clades},
+        }
+
+        observed = svc._summarize_simulations(
+            [mapping], ["x", "y"], LegacyTree()
+        )
+
+        assert observed["mean_dwelling_times"][0] > 0.0
+        assert observed["mean_dwelling_times"][1] == 0.0
+
+    def test_summarize_simulations_recovers_from_malformed_direct_traversal(
+        self, default_args
+    ):
+        svc = StochasticCharacterMap(default_args)
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        clades = list(tree.find_clades(order="preorder"))
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+            def find_clades(self, *args, **kwargs):
+                return tree.find_clades(*args, **kwargs)
+
+        mapping = {
+            "branch_histories": {
+                id(clades[1]): [(0.0, 0), (0.5, 0)],
+                id(object()): [(0.0, 1)],
+            },
+            "node_states": {id(clade): 0 for clade in clades},
+        }
+
+        observed = svc._summarize_simulations(
+            [mapping], ["x", "y"], MalformedTree()
+        )
+
+        assert observed["mean_dwelling_times"][0] > 0.0
+        assert observed["mean_transitions"].sum() == 0.0
+
     def test_summarize_simulations_accumulates_with_single_traversal(
         self, default_args, monkeypatch
     ):
@@ -1617,6 +1783,77 @@ class TestRun:
             },
         )
         monkeypatch.setattr(svc, "_print_text_output", lambda *_args, **_kwargs: None)
+
+    def test_run_rejects_invariant_character_states(
+        self, default_args, monkeypatch
+    ):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1);"), "newick")
+        svc = StochasticCharacterMap(default_args)
+        monkeypatch.setattr(svc, "read_tree_file_unmodified", lambda: tree)
+        monkeypatch.setattr(
+            svc,
+            "_parse_discrete_trait_file",
+            lambda *_args, **_kwargs: {"A": "x", "B": "x", "C": "x"},
+        )
+
+        with pytest.raises(PhykitUserError) as excinfo:
+            svc.run()
+
+        assert "At least 2 distinct character states" in excinfo.value.messages[0]
+
+    def test_run_ladderizes_a_copy_of_read_only_tree(
+        self, default_args, monkeypatch
+    ):
+        default_args.nsim = 0
+        default_args.ladderize = True
+        tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
+        svc = StochasticCharacterMap(default_args)
+        captured_tree = {}
+        copied_trees = []
+        real_copy = svc._fast_copy
+
+        def copy_spy(value):
+            copied = real_copy(value)
+            copied_trees.append(copied)
+            return copied
+
+        monkeypatch.setattr(svc, "read_tree_file_unmodified", lambda: tree)
+        monkeypatch.setattr(
+            svc,
+            "_parse_discrete_trait_file",
+            lambda *_args, **_kwargs: {
+                "A": "x",
+                "B": "x",
+                "C": "y",
+                "D": "y",
+            },
+        )
+        monkeypatch.setattr(svc, "_fast_copy", copy_spy)
+        self._stub_expensive_run_tail(svc, monkeypatch, captured_tree)
+
+        svc.run()
+
+        assert len(copied_trees) == 1
+        assert captured_tree["tree"] is copied_trees[0]
+        assert captured_tree["tree"] is not tree
+
+    def test_format_result_includes_plot_output(self, default_args):
+        svc = StochasticCharacterMap(default_args)
+        summary = {
+            "mean_dwelling_times": np.array([0.0, 0.0]),
+            "mean_transitions": np.zeros((2, 2)),
+        }
+
+        observed = svc._format_result(
+            np.array([[-1.0, 1.0], [1.0, -1.0]]),
+            -1.0,
+            ["x", "y"],
+            summary,
+            "map.png",
+        )
+
+        assert observed["plot_output"] == "map.png"
+        assert observed["mean_dwelling_proportions"] == {"x": 0.0, "y": 0.0}
 
     def test_all_tips_present_uses_read_only_tree_without_copy_or_prune(
         self, default_args, monkeypatch

--- a/tests/unit/services/tree/test_terminal_branch_stats_service.py
+++ b/tests/unit/services/tree/test_terminal_branch_stats_service.py
@@ -260,6 +260,53 @@ class TestTerminalBranchStats:
 
         assert lengths.tolist() == [1.0, 2.0, 4.0]
 
+    def test_direct_traversals_support_multifurcating_nodes(self, args):
+        tree = Phylo.read(StringIO("(A:1,B:2,C:3);"), "newick")
+
+        lengths, rows = TerminalBranchStats._get_terminal_branch_lengths_direct(
+            tree
+        )
+        lengths_array = (
+            TerminalBranchStats._get_terminal_branch_lengths_array_direct(tree)
+        )
+
+        assert lengths == [1.0, 2.0, 3.0]
+        assert rows == [[1.0, "A"], [2.0, "B"], [3.0, "C"]]
+        assert lengths_array.tolist() == lengths
+
+    def test_direct_traversals_reject_incompatible_tree_objects(self, args):
+        class MalformedChild:
+            branch_length = 1.0
+            name = "A"
+
+        class MalformedRoot:
+            clades = [MalformedChild()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        assert TerminalBranchStats._get_terminal_branch_lengths_direct(
+            object()
+        ) is None
+        assert TerminalBranchStats._get_terminal_branch_lengths_array_direct(
+            object()
+        ) is None
+        assert TerminalBranchStats._get_terminal_branch_lengths_direct(
+            MalformedTree()
+        ) is None
+        assert TerminalBranchStats._get_terminal_branch_lengths_array_direct(
+            MalformedTree()
+        ) is None
+
+    def test_array_stats_reject_tree_without_terminal_branch_lengths(self, args):
+        service = TerminalBranchStats(args)
+        tree = Phylo.read(StringIO("(A,B,C);"), "newick")
+
+        with pytest.raises(SystemExit) as exc_info:
+            service.calculate_terminal_branch_stats(tree, include_names=False)
+
+        assert exc_info.value.code == 2
+
     def test_scan_simple_newick_terminal_branches_preserves_order(self, tmp_path):
         tree_file = tmp_path / "tree.tre"
         tree_file.write_text("((A:1,B:2):3,(C,D:4):5);\n")
@@ -274,6 +321,58 @@ class TestTerminalBranchStats:
     def test_scan_simple_newick_terminal_branches_rejects_annotations(self, tmp_path):
         tree_file = tmp_path / "tree.tre"
         tree_file.write_text("((A:1,B:2):3[comment],C:4);\n")
+
+        result = TerminalBranchStats._scan_simple_newick_terminal_branches(
+            str(tree_file)
+        )
+
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "newick",
+        [
+            ":1;",
+            "A:;",
+            "A:not-a-number;",
+            "(",
+            "(A:1",
+            "(A:1 X",
+            "(A:1):;",
+            "A:1",
+            "A:1; trailing",
+        ],
+        ids=[
+            "empty-label",
+            "empty-length",
+            "invalid-length",
+            "missing-child",
+            "unterminated-group",
+            "invalid-separator",
+            "invalid-internal-length",
+            "missing-semicolon",
+            "trailing-content",
+        ],
+    )
+    def test_scan_simple_newick_rejects_malformed_syntax(
+        self, tmp_path, newick
+    ):
+        tree_file = tmp_path / "malformed.tre"
+        tree_file.write_text(newick)
+
+        result = TerminalBranchStats._scan_simple_newick_terminal_branches(
+            str(tree_file)
+        )
+
+        assert result is None
+
+    def test_scan_simple_newick_falls_back_when_recursion_limit_is_reached(
+        self, tmp_path
+    ):
+        depth = sys.getrecursionlimit() + 10
+        tree_file = tmp_path / "deep-tree.tre"
+        tree_file.write_text(
+            "(" * depth + "A:1" + ")" * depth + ";"
+        )
 
         result = TerminalBranchStats._scan_simple_newick_terminal_branches(
             str(tree_file)
@@ -297,6 +396,50 @@ class TestTerminalBranchStats:
 
         out, _ = capsys.readouterr()
         assert out == "1.1235 A\n2.0 B\n4.0 C\n"
+
+    def test_run_simple_newick_fast_path_prints_summary(self, tmp_path, mocker):
+        tree_file = tmp_path / "tree.tre"
+        tree_file.write_text("(A:1,B:2,C:3);\n")
+        service = TerminalBranchStats(
+            Namespace(tree=str(tree_file), verbose=False, json=False)
+        )
+        mocked_stats = mocker.patch.object(
+            tbs_module,
+            "calculate_summary_statistics_from_arr",
+            return_value={"mean": 2.0},
+        )
+        mocked_print = mocker.patch.object(
+            tbs_module,
+            "print_summary_statistics",
+        )
+
+        service.run()
+
+        mocked_stats.assert_called_once_with([1.0, 2.0, 3.0])
+        mocked_print.assert_called_once_with({"mean": 2.0})
+
+    def test_run_simple_newick_fast_path_prints_json_summary(
+        self, tmp_path, mocker
+    ):
+        tree_file = tmp_path / "tree.tre"
+        tree_file.write_text("(A:1,B:2,C:3);\n")
+        service = TerminalBranchStats(
+            Namespace(tree=str(tree_file), verbose=False, json=True)
+        )
+        mocker.patch.object(
+            tbs_module,
+            "calculate_summary_statistics_from_arr",
+            return_value={"mean": 2.0},
+        )
+        mocked_json = mocker.patch.object(tbs_module, "print_json")
+
+        service.run()
+
+        stats_input = tbs_module.calculate_summary_statistics_from_arr.call_args.args[0]
+        assert stats_input.tolist() == [1.0, 2.0, 3.0]
+        mocked_json.assert_called_once_with(
+            {"verbose": False, "summary": {"mean": 2.0}}
+        )
 
     def test_run_non_verbose_prints_summary(self, mocker):
         args = Namespace(tree="/some/path/to/file.tre", verbose=False, json=False)

--- a/tests/unit/services/tree/test_threshold_model.py
+++ b/tests/unit/services/tree/test_threshold_model.py
@@ -2,7 +2,6 @@ import builtins
 import importlib
 import json
 import math
-import os
 import subprocess
 import sys
 from argparse import Namespace
@@ -15,6 +14,7 @@ from Bio import Phylo
 from Bio.Phylo.BaseTree import TreeMixin
 
 import phykit.services.tree.threshold_model as threshold_model_module
+from phykit.services.tree.base import Tree
 from phykit.services.tree.threshold_model import ThresholdModel
 from phykit.errors import PhykitUserError
 
@@ -206,6 +206,47 @@ class TestProcessArgs:
         with pytest.raises(SystemExit):
             ThresholdModel(args)
 
+    @pytest.mark.parametrize("traits", ["one", "one,two,three"])
+    def test_requires_exactly_two_trait_names(self, traits):
+        args = Namespace(
+            tree="t.tre",
+            trait_data="traits.tsv",
+            traits=traits,
+            types="discrete,continuous",
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ThresholdModel(args)
+
+        assert "Expected exactly 2 trait names" in exc_info.value.messages[0]
+
+    def test_missing_types_raises(self):
+        args = Namespace(
+            tree="t.tre",
+            trait_data="traits.tsv",
+            traits="one,two",
+            types=None,
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ThresholdModel(args)
+
+        assert "Two trait types must be specified" in exc_info.value.messages[0]
+
+    @pytest.mark.parametrize("types", ["continuous", "continuous,discrete,continuous"])
+    def test_requires_exactly_two_trait_types(self, types):
+        args = Namespace(
+            tree="t.tre",
+            trait_data="traits.tsv",
+            traits="one,two",
+            types=types,
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ThresholdModel(args)
+
+        assert "Expected exactly 2 trait types" in exc_info.value.messages[0]
+
     def test_invalid_type_raises(self):
         args = Namespace(
             tree="t.tre",
@@ -235,6 +276,63 @@ class TestParseMultiTraitFile:
         assert t1["A"] == 0.0
         assert t1["B"] == 1.0
         assert abs(t2["A"] - 1.5) < 1e-10
+
+    @pytest.mark.parametrize(
+        ("contents", "trait1", "trait2", "expected_message"),
+        [
+            pytest.param("", "t1", "t2", "Trait file is empty", id="empty-file"),
+            pytest.param(
+                "taxon\nA\n",
+                "t1",
+                "t2",
+                "at least 2 tab-separated columns",
+                id="short-header",
+            ),
+            pytest.param(
+                "taxon\tt1\tt2\nA\t0\t1\n",
+                "missing",
+                "t2",
+                "Trait 'missing' not found",
+                id="first-trait-missing",
+            ),
+            pytest.param(
+                "taxon\tt1\tt2\nA\tnot-a-number\t1\n",
+                "t1",
+                "t2",
+                "Non-numeric value 'not-a-number' for trait 't1'",
+                id="first-trait-nonnumeric",
+            ),
+            pytest.param(
+                "taxon\tt1\tt2\nA\t0\tnot-a-number\n",
+                "t1",
+                "t2",
+                "Non-numeric value 'not-a-number' for trait 't2'",
+                id="second-trait-nonnumeric",
+            ),
+        ],
+    )
+    def test_trait_file_validation_errors(
+        self,
+        tmp_path,
+        contents,
+        trait1,
+        trait2,
+        expected_message,
+    ):
+        trait_file = tmp_path / "invalid-traits.tsv"
+        trait_file.write_text(contents)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            ThresholdModel._parse_multi_trait_file(
+                str(trait_file),
+                trait1,
+                trait2,
+                "continuous",
+                "continuous",
+                ["A", "B", "C"],
+            )
+
+        assert expected_message in exc_info.value.messages[0]
 
     def test_comments_blanks_and_extra_columns(self, tmp_path):
         trait_file = tmp_path / "traits.tsv"
@@ -430,6 +528,40 @@ class TestBuildVCVMatrix:
         ThresholdModel._prune_tree_to_taxa(tree, {"A", "C"})
 
         assert {tip.name for tip in original_get_terminals(tree)} == {"A", "C"}
+
+    def test_prune_tree_to_taxa_uses_generic_tree_fallback(self, monkeypatch):
+        tree = _make_tree()
+        monkeypatch.setattr(Tree, "_terminal_by_name_fast", lambda _tree: None)
+
+        ThresholdModel._prune_tree_to_taxa(tree, {"A", "C"})
+
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "C"}
+
+    def test_prune_tree_to_taxa_is_noop_when_all_taxa_are_retained(self, monkeypatch):
+        tree = _make_tree()
+        monkeypatch.setattr(
+            TreeMixin,
+            "prune",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("no tips should be pruned")
+            ),
+        )
+
+        ThresholdModel._prune_tree_to_taxa(tree, {"A", "B", "C", "D"})
+
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "B", "C", "D"}
+
+    def test_prune_tree_to_taxa_falls_back_to_individual_pruning(self, monkeypatch):
+        tree = _make_tree()
+        monkeypatch.setattr(
+            Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            lambda *_args, **_kwargs: False,
+        )
+
+        ThresholdModel._prune_tree_to_taxa(tree, {"A", "C"})
+
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "C"}
 
 
 class TestInitializeLiabilities:

--- a/tests/unit/services/tree/test_threshold_model.py
+++ b/tests/unit/services/tree/test_threshold_model.py
@@ -90,6 +90,19 @@ def test_lazy_numpy_caches_resolved_attributes():
     assert lazy_np._module is not None
 
 
+def test_special_function_wrappers_cache_resolved_functions(monkeypatch):
+    monkeypatch.setattr(threshold_model_module, "_NDTR", None)
+    monkeypatch.setattr(threshold_model_module, "_NDTRI", None)
+
+    assert threshold_model_module.ndtr(0.0) == pytest.approx(0.5)
+    assert threshold_model_module.ndtri(0.5) == pytest.approx(0.0)
+    cached_ndtr = threshold_model_module._NDTR
+    cached_ndtri = threshold_model_module._NDTRI
+
+    assert threshold_model_module.ndtr(1.0) == cached_ndtr(1.0)
+    assert threshold_model_module.ndtri(0.75) == cached_ndtri(0.75)
+
+
 def test_vcv_inverse_and_logdet_cholesky_matches_inverse_and_slogdet():
     rng = np.random.default_rng(20260628)
     A = rng.normal(size=(8, 8))
@@ -137,6 +150,15 @@ def test_vcv_inverse_and_logdet_keeps_inverse_fallback():
 
     np.testing.assert_allclose(observed_inv, expected_inv)
     assert observed_logdet == pytest.approx(expected_logdet)
+
+
+def test_vcv_inverse_rejects_non_positive_definite_matrix():
+    matrix = np.array([[1.0, 2.0], [2.0, 1.0]])
+
+    with pytest.raises(PhykitUserError) as exc_info:
+        ThresholdModel._vcv_inverse_and_logdet(matrix)
+
+    assert exc_info.value.messages == ["VCV matrix is not positive definite."]
 
 
 def _make_tree():
@@ -747,6 +769,34 @@ class TestLogLikelihoodBivariateBM:
 
         assert ll_pos > ll_neg
 
+    @pytest.mark.parametrize(
+        ("stats", "sigma2_1", "sigma2_2", "r", "logdet_C"),
+        [
+            pytest.param((1.0, 0.0, 1.0, 0.0, 0.0, 1.0), np.nan, 1.0, 0.0, 0.0, id="non-finite-variance"),
+            pytest.param((1.0, 0.0, 1.0, 0.0, 0.0, 1.0), 0.0, 1.0, 0.0, 0.0, id="non-positive-variance"),
+            pytest.param((1.0, 0.0, 1.0, 0.0, 0.0, 1.0), 1.0, 1.0, 1.0, 0.0, id="singular-correlation"),
+            pytest.param((1.0, 0.0, 1.0, 0.0, 0.0, 1.0), 5e-324, 1.0, 0.5, 0.0, id="overflowing-inverse"),
+            pytest.param((np.nan, 0.0, 1.0, 0.0, 0.0, 1.0), 1.0, 1.0, 0.0, 0.0, id="non-finite-statistic"),
+            pytest.param((1e200, 0.0, 1.0, 0.0, 0.0, 1.0), 1e-200, 1.0, 0.0, 0.0, id="overflowing-quadratic"),
+            pytest.param((1.0, 0.0, 1.0, 0.0, 0.0, 1.0), 1.0, 1.0, 0.0, np.inf, id="non-finite-likelihood"),
+        ],
+    )
+    def test_invalid_parameters_and_statistics_return_negative_infinity(
+        self, stats, sigma2_1, sigma2_2, r, logdet_C
+    ):
+        observed = ThresholdModel._log_likelihood_bivariate_bm_from_stats(
+            stats,
+            sigma2_1,
+            sigma2_2,
+            r,
+            0.0,
+            0.0,
+            logdet_C,
+            1,
+        )
+
+        assert observed == -np.inf
+
 
 class TestSampleLiabilitiesGibbs:
     def test_inverse_cdf_truncated_normal_respects_bounds(self):
@@ -762,6 +812,119 @@ class TestSampleLiabilitiesGibbs:
 
         assert np.all(lower_samples <= 0.0)
         assert np.all(upper_samples >= 0.0)
+
+    def test_two_sided_truncated_normal_respects_bounds(self, monkeypatch):
+        monkeypatch.setattr(threshold_model_module, "_NDTRI", None)
+        rng = np.random.default_rng(20260717)
+
+        samples = np.array(
+            [
+                ThresholdModel._sample_truncated_normal(
+                    0.25,
+                    1.2,
+                    -0.5,
+                    1.0,
+                    rng,
+                )
+                for _ in range(100)
+            ]
+        )
+
+        assert np.all(samples >= -0.5)
+        assert np.all(samples <= 1.0)
+
+    def test_two_sided_truncated_normal_uses_scipy_fallback_for_empty_interval(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            threshold_model_module,
+            "_truncnorm_rvs",
+            lambda *_args, **_kwargs: 12.5,
+        )
+
+        observed = ThresholdModel._sample_truncated_normal(
+            0.0,
+            1.0,
+            1.0,
+            -1.0,
+            np.random.default_rng(1),
+        )
+
+        assert observed == 12.5
+
+    def test_truncated_normal_helpers_clamp_extreme_probabilities(self, monkeypatch):
+        probabilities = []
+
+        class FixedRng:
+            def __init__(self, value):
+                self.value = value
+
+            def random(self):
+                return self.value
+
+        def capture_probability(value):
+            probabilities.append(value)
+            return 0.0
+
+        monkeypatch.setattr(threshold_model_module, "_NDTRI", capture_probability)
+
+        for random_value in (0.0, 1.0):
+            ThresholdModel._sample_truncated_normal(
+                0.0,
+                1.0,
+                -np.inf,
+                np.inf,
+                FixedRng(random_value),
+            )
+            ThresholdModel._sample_truncated_normal_below_zero(
+                -1_000.0,
+                1.0,
+                FixedRng(random_value),
+            )
+            ThresholdModel._sample_truncated_normal_above_zero(
+                1_000.0,
+                1.0,
+                FixedRng(random_value),
+            )
+
+        assert probabilities == [
+            ThresholdModel._FLOAT_TINY,
+            ThresholdModel._FLOAT_TINY,
+            ThresholdModel._FLOAT_TINY,
+            ThresholdModel._ONE_MINUS_EPS,
+            ThresholdModel._ONE_MINUS_EPS,
+            ThresholdModel._ONE_MINUS_EPS,
+        ]
+
+    @pytest.mark.parametrize(
+        ("sampler", "mu", "expected"),
+        [
+            pytest.param(
+                ThresholdModel._sample_truncated_normal_below_zero,
+                1_000.0,
+                -12.5,
+                id="below-zero",
+            ),
+            pytest.param(
+                ThresholdModel._sample_truncated_normal_above_zero,
+                -1_000.0,
+                12.5,
+                id="above-zero",
+            ),
+        ],
+    )
+    def test_one_sided_truncated_normal_uses_scipy_fallback(
+        self, monkeypatch, sampler, mu, expected
+    ):
+        monkeypatch.setattr(
+            threshold_model_module,
+            "_truncnorm_rvs",
+            lambda *_args, **_kwargs: expected,
+        )
+
+        observed = sampler(mu, 1.0, np.random.default_rng(1))
+
+        assert observed == expected
 
     def test_one_sided_truncated_normal_matches_inverse_cdf(self):
         def reference(mu, sd, lower, upper, rng):
@@ -1093,6 +1256,100 @@ class TestSampleLiabilitiesGibbs:
         assert np.all(observed[states == 0] <= 0.0)
         assert np.all(observed[states == 1] >= 0.0)
 
+    def test_gibbs_sampler_skips_invalid_conditionals(self):
+        liabilities = np.array([-0.5])
+        states = np.array([0])
+        matrix = np.array([[1.0]])
+        invalid_context = {
+            "c_inv_diag": np.array([1.0]),
+            "sd_cond": np.array([1.0]),
+            "valid": np.array([False]),
+        }
+
+        invalid_from_context = ThresholdModel._sample_liabilities_gibbs(
+            liabilities,
+            states,
+            matrix,
+            matrix,
+            1.0,
+            0.0,
+            liabilities,
+            1.0,
+            0.0,
+            0.0,
+            np.random.default_rng(1),
+            invalid_context,
+        )
+        zero_precision = ThresholdModel._sample_liabilities_gibbs(
+            liabilities,
+            states,
+            matrix,
+            np.array([[0.0]]),
+            1.0,
+            0.0,
+            liabilities,
+            1.0,
+            0.0,
+            0.0,
+            np.random.default_rng(1),
+        )
+        invalid_variance = ThresholdModel._sample_liabilities_gibbs(
+            liabilities,
+            states,
+            matrix,
+            matrix,
+            -1.0,
+            0.0,
+            liabilities,
+            1.0,
+            0.0,
+            0.0,
+            np.random.default_rng(1),
+        )
+
+        np.testing.assert_array_equal(invalid_from_context, liabilities)
+        np.testing.assert_array_equal(zero_precision, liabilities)
+        np.testing.assert_array_equal(invalid_variance, liabilities)
+
+    @pytest.mark.parametrize(
+        ("state", "cdf", "fallback_value"),
+        [
+            pytest.param(0, 0.0, -0.25, id="below-zero"),
+            pytest.param(1, 1.0, 0.25, id="above-zero"),
+        ],
+    )
+    def test_gibbs_sampler_uses_scipy_for_degenerate_tail(
+        self, monkeypatch, state, cdf, fallback_value
+    ):
+        monkeypatch.setattr(threshold_model_module, "_NDTR", lambda _value: cdf)
+        monkeypatch.setattr(
+            threshold_model_module,
+            "_truncnorm_rvs",
+            lambda *_args, **_kwargs: fallback_value,
+        )
+        liabilities = np.array([-0.5 if state == 0 else 0.5])
+
+        observed = ThresholdModel._sample_liabilities_gibbs(
+            liabilities,
+            np.array([state]),
+            np.eye(1),
+            np.eye(1),
+            1.0,
+            0.0,
+            liabilities,
+            1.0,
+            0.0,
+            0.0,
+            np.random.default_rng(1),
+        )
+
+        assert observed[0] == fallback_value
+
+    def test_prepare_gibbs_context_invalid_variance_disables_all_tips(self):
+        context = ThresholdModel._prepare_gibbs_context(np.eye(3), -1.0)
+
+        np.testing.assert_array_equal(context["valid"], [False, False, False])
+
 
 class TestComputeHPD:
     def test_known_normal_samples(self):
@@ -1185,6 +1442,22 @@ class TestComputeHPD:
         summary = ThresholdModel._summarize_posterior(mcmc_result)
 
         assert summary["r"]["mean"] == pytest.approx(float(samples.mean()))
+
+    def test_sample_mean_accepts_plain_sequences(self):
+        assert ThresholdModel._sample_mean([1.0, 2.0, 3.0]) == 2.0
+
+    def test_summarize_posterior_handles_empty_traces(self):
+        mcmc_result = {
+            param: np.array([])
+            for param in ("r", "sigma2_1", "sigma2_2", "a1", "a2")
+        }
+        mcmc_result["acceptance_rates"] = {"r": 0.0}
+
+        summary = ThresholdModel._summarize_posterior(mcmc_result)
+
+        for param in ("r", "sigma2_1", "sigma2_2", "a1", "a2"):
+            assert all(math.isnan(value) for value in summary[param].values())
+        assert summary["acceptance_rates"] == {"r": 0.0}
 
 
 class TestRunMCMC:
@@ -1412,6 +1685,73 @@ class TestRunMCMC:
         assert len(result["r"]) > 0
         assert np.all(result["sigma2_1"] > 0)
 
+    def test_continuous_discrete_updates_second_trait_liabilities(self):
+        tree = _make_tree()
+        names = sorted(tip.name for tip in tree.get_terminals())
+        C = ThresholdModel._build_vcv_matrix(tree, names)
+        trait1 = {"A": 0.2, "B": 1.0, "C": 0.4, "D": 1.2}
+        trait2 = {"A": 0.0, "B": 1.0, "C": 0.0, "D": 1.0}
+
+        result = ThresholdModel._run_mcmc(
+            trait1,
+            trait2,
+            "continuous",
+            "discrete",
+            names,
+            C,
+            5,
+            1,
+            0.0,
+            np.random.default_rng(20260717),
+        )
+
+        np.testing.assert_array_equal(result["sigma2_2"], np.ones(5))
+        np.testing.assert_array_equal(result["a2"], np.zeros(5))
+
+    def test_zero_generation_chain_returns_empty_samples(self):
+        names = ["A", "B"]
+        traits = {"A": 1.0, "B": 2.0}
+
+        result = ThresholdModel._run_mcmc(
+            traits,
+            traits,
+            "continuous",
+            "continuous",
+            names,
+            np.eye(2),
+            0,
+            1,
+            0.0,
+            np.random.default_rng(20260717),
+        )
+
+        assert result["r"].size == 0
+        assert all(rate == 0.0 for rate in result["acceptance_rates"].values())
+
+    def test_non_positive_mean_diagonal_uses_unit_scale(self, monkeypatch):
+        names = ["A", "B"]
+        traits = {"A": 1.0, "B": 2.0}
+        monkeypatch.setattr(
+            ThresholdModel,
+            "_vcv_inverse_and_logdet",
+            staticmethod(lambda _matrix: (np.eye(2), 0.0)),
+        )
+
+        result = ThresholdModel._run_mcmc(
+            traits,
+            traits,
+            "continuous",
+            "continuous",
+            names,
+            np.zeros((2, 2)),
+            1,
+            1,
+            0.0,
+            np.random.default_rng(20260717),
+        )
+
+        assert result["sigma2_1"].shape == (1,)
+
 
 class TestRun:
     @staticmethod
@@ -1586,6 +1926,20 @@ class TestRun:
             "sigma2_2=0.346, a1=0.457, a2=0.568"
         )
 
+    def test_output_text_ignores_broken_pipe(self, monkeypatch):
+        svc = ThresholdModel(self._make_args())
+        summary = {
+            param: {"mean": 0.0, "hpd_lower": -1.0, "hpd_upper": 1.0}
+            for param in ("r", "sigma2_1", "sigma2_2")
+        }
+        summary["acceptance_rates"] = {}
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BrokenPipeError),
+        )
+
+        assert svc._output_text(summary) is None
+
     def test_json_output(self, capsys):
         args = Namespace(
             tree=TREE_SIMPLE,
@@ -1631,6 +1985,32 @@ class TestRun:
         monkeypatch.setattr(Figure, "tight_layout", fail_tight_layout)
 
         output_path = tmp_path / "trace.png"
+        svc._plot_trace(mcmc_result, str(output_path))
+
+        assert output_path.exists()
+
+    def test_plot_trace_handles_fixed_parameters_without_titles(
+        self, monkeypatch, tmp_path
+    ):
+        pytest.importorskip("matplotlib")
+        import matplotlib
+        from matplotlib.axes import Axes
+
+        matplotlib.use("Agg")
+        svc = ThresholdModel(self._make_args())
+        svc.plot_config.show_title = False
+        mcmc_result = {
+            "r": np.array([-0.2, 0.0, 0.2, 0.4]),
+            "sigma2_1": np.ones(4),
+            "sigma2_2": np.full(4, 2.0),
+        }
+
+        def fail_set_title(*_args, **_kwargs):
+            raise AssertionError("titles should be disabled")
+
+        monkeypatch.setattr(Axes, "set_title", fail_set_title)
+
+        output_path = tmp_path / "fixed-trace.png"
         svc._plot_trace(mcmc_result, str(output_path))
 
         assert output_path.exists()

--- a/tests/unit/services/tree/test_tip_to_tip_node_distance_service.py
+++ b/tests/unit/services/tree/test_tip_to_tip_node_distance_service.py
@@ -91,6 +91,18 @@ class TestTipToTipNodeDistance:
             service.check_leaves(_Tree(), "missing", "b")
         assert excinfo.value.code == 2
 
+    def test_check_leaves_exits_when_second_missing(self, mocker, args):
+        service = TipToTipNodeDistance(args)
+        mocker.patch(
+            "phykit.services.tree.tip_to_tip_node_distance.TreeMixin.find_any",
+            side_effect=[object(), None],
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            service.check_leaves(_Tree(), "a", "missing")
+
+        assert excinfo.value.code == 2
+
     def test_run_text_output(self, mocker):
         args = Namespace(tree_zero="/some/path/to/file.tre", tip_1="a", tip_2="b", json=False)
         service = TipToTipNodeDistance(args)
@@ -135,6 +147,24 @@ class TestTipToTipNodeDistance:
 
         assert service.calculate_tip_to_tip_node_distance(tree, "A", "C") == 3
 
+    def test_fast_node_distance_supports_multifurcations(self, args):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1,D:1);"), "newick")
+        service = TipToTipNodeDistance(args)
+
+        observed = service.calculate_tip_to_tip_node_distance(tree, "A", "D")
+
+        assert observed == len(TreeMixin.trace(tree, "A", "D"))
+
+    def test_fast_node_distance_reports_missing_first_tip(self, args, capsys):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        service = TipToTipNodeDistance(args)
+
+        with pytest.raises(SystemExit) as excinfo:
+            service.calculate_tip_to_tip_node_distance(tree, "missing", "B")
+
+        assert excinfo.value.code == 2
+        assert "missing not on tree" in capsys.readouterr().out
+
     def test_fast_node_distance_does_not_build_root_paths(self, args, mocker):
         tree = Phylo.read(StringIO("(((A:1,B:1):1,C:2):1,D:3);"), "newick")
         service = TipToTipNodeDistance(args)
@@ -175,6 +205,44 @@ class TestTipToTipNodeDistance:
         )
 
         assert service.calculate_tip_to_tip_node_distance(tree, "C", "C") == 0
+
+    def test_fast_same_tip_supports_multifurcations(self, args):
+        tree = Phylo.read(StringIO("(A:1,B:1,C:1,D:1);"), "newick")
+        service = TipToTipNodeDistance(args)
+
+        assert service.calculate_tip_to_tip_node_distance(tree, "D", "D") == 0
+
+    def test_fast_same_tip_returns_none_for_incomplete_clade_interface(self):
+        root = _ChildListClade(clades=[object()])
+
+        observed = TipToTipNodeDistance._calculate_same_tip_node_distance_fast(
+            root, "A"
+        )
+
+        assert observed is None
+
+    def test_fast_same_tip_reports_missing_taxon(self, args, capsys):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        service = TipToTipNodeDistance(args)
+
+        with pytest.raises(SystemExit) as excinfo:
+            service.calculate_tip_to_tip_node_distance(
+                tree, "missing", "missing"
+            )
+
+        assert excinfo.value.code == 2
+        assert "missing not on tree" in capsys.readouterr().out
+
+    def test_path_to_root_returns_nodes_in_root_first_order(self, args):
+        tree = Phylo.read(StringIO("((A:1,B:1):1,C:1);"), "newick")
+        service = TipToTipNodeDistance(args)
+        leaf = next(tree.find_clades(name="A"))
+        parent = tree.root.clades[0]
+        parent_map = {leaf: parent, parent: tree.root}
+
+        path = service._path_to_root(leaf, tree.root, parent_map)
+
+        assert path == [tree.root, parent, leaf]
 
     def test_run_standard_tree_avoids_trace(self, mocker):
         tree = Phylo.read(StringIO("((A:1,B:1):1,C:2);"), "newick")

--- a/tests/unit/services/tree/test_trait_rate_map.py
+++ b/tests/unit/services/tree/test_trait_rate_map.py
@@ -1038,6 +1038,28 @@ class TestPlotRateMap:
 
 
 class TestRun:
+    @pytest.mark.parametrize("circular", [False, True])
+    def test_color_annotations_render_in_both_layouts(self, tmp_path, circular):
+        pytest.importorskip("matplotlib")
+        color_file = tmp_path / "colors.tsv"
+        color_file.write_text(
+            "raccoon,bear\trange\t#ffcc00\tHighlighted taxa\n"
+            "raccoon\tlabel\t#0033cc\n"
+        )
+        output = tmp_path / f"trait-rate-{circular}.png"
+        svc = TraitRateMap(
+            _make_args(
+                output=str(output),
+                color_file=str(color_file),
+                circular=circular,
+            )
+        )
+
+        svc.run()
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
     def test_creates_png(self):
         try:
             import matplotlib

--- a/tests/unit/services/tree/test_trait_rate_map.py
+++ b/tests/unit/services/tree/test_trait_rate_map.py
@@ -83,6 +83,15 @@ class TestProcessArgs:
 
 
 class TestSingleTraitParsing:
+    def test_missing_file_reports_path(self, tmp_path):
+        missing = tmp_path / "missing.tsv"
+        svc = TraitRateMap.__new__(TraitRateMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_single_trait_data(str(missing), ["A", "B", "C"])
+
+        assert str(missing) in exc_info.value.messages[0]
+
     def test_comments_and_blanks(self, tmp_path):
         trait_file = tmp_path / "traits.tsv"
         trait_file.write_text(
@@ -214,8 +223,95 @@ class TestTextOutput:
             "Output: trait_rate.png"
         )
 
+    def test_print_text_output_handles_empty_rates(self, mocker):
+        svc = TraitRateMap.__new__(TraitRateMap)
+        svc.output_path = "empty.png"
+        printed = mocker.patch("builtins.print")
+
+        svc._print_text_output(3, "mass", 0.0, None, None)
+
+        printed.assert_called_once_with(
+            "Trait Rate Map\n"
+            "Taxa: 3\n"
+            "Trait: mass\n"
+            "Mean rate: 0.0000\n"
+            "Output: empty.png"
+        )
+
 
 class TestTraitDataParsing:
+    @pytest.mark.parametrize(
+        ("contents", "column", "message"),
+        [
+            ("# comment\n\n", "mass", "must have a header row"),
+            (
+                "taxon\tmass\nA\t1\nB\t2\nC\t3\n",
+                "height",
+                "Column 'height' not found",
+            ),
+            ("taxon\tmass\nA\n", "mass", "too few columns"),
+            ("taxon\tmass\n# no data\n", "mass", "must have a header row"),
+        ],
+    )
+    def test_multi_trait_parser_reports_structural_errors(
+        self, tmp_path, contents, column, message
+    ):
+        trait_file = tmp_path / "traits.tsv"
+        trait_file.write_text(contents)
+        svc = TraitRateMap.__new__(TraitRateMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_multi_trait_data(
+                str(trait_file), ["A", "B", "C"], column
+            )
+
+        assert message in exc_info.value.messages[0]
+
+    def test_multi_trait_parser_reports_missing_path(self, tmp_path):
+        missing = tmp_path / "missing.tsv"
+        svc = TraitRateMap.__new__(TraitRateMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_multi_trait_data(
+                str(missing), ["A", "B", "C"], "mass"
+            )
+
+        assert str(missing) in exc_info.value.messages[0]
+
+    def test_intersect_traits_accepts_unordered_exact_taxa(self, capsys):
+        svc = TraitRateMap.__new__(TraitRateMap)
+        traits = {"C": 3.0, "A": 1.0, "B": 2.0}
+
+        assert svc._intersect_traits(traits, ["A", "B", "C"]) is traits
+        assert capsys.readouterr().err == ""
+
+    def test_intersect_traits_warns_for_both_mismatch_directions(self, capsys):
+        svc = TraitRateMap.__new__(TraitRateMap)
+
+        shared = svc._intersect_traits(
+            {"A": 1.0, "B": 2.0, "C": 3.0, "extra": 4.0},
+            ["A", "B", "C", "missing"],
+        )
+
+        assert shared == {"A": 1.0, "B": 2.0, "C": 3.0}
+        stderr = capsys.readouterr().err
+        assert "missing" in stderr
+        assert "extra" in stderr
+
+    def test_intersect_traits_rejects_too_few_shared_taxa(self, capsys):
+        svc = TraitRateMap.__new__(TraitRateMap)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._intersect_traits(
+                {"A": 1.0, "B": 2.0, "extra": 3.0},
+                ["A", "B", "missing"],
+            )
+
+        assert "Only 2 shared taxa" in exc_info.value.messages[0]
+        stderr = capsys.readouterr().err
+        assert "missing" in stderr
+        assert "extra" in stderr
+
     def test_multi_trait_parser_streams_without_readlines(self, monkeypatch):
         class StreamingOnlyFile(StringIO):
             def __enter__(self):
@@ -337,8 +433,26 @@ class TestAncestralReconstruction:
             if os.path.exists(tmppath):
                 os.unlink(tmppath)
 
+    def test_missing_tip_values_are_ignored(self):
+        svc = TraitRateMap.__new__(TraitRateMap)
+        tree = Phylo.read(StringIO("(A:1,B:1);"), "newick")
+
+        one_value = svc._ancestral_reconstruction(tree, {"A": 4.0})
+        no_values = svc._ancestral_reconstruction(tree, {})
+
+        assert one_value[id(tree.root)] == pytest.approx(4.0)
+        assert id(tree.root) not in no_values
+
 
 class TestBranchRates:
+    def test_internal_labels_preserve_existing_names(self):
+        svc = TraitRateMap.__new__(TraitRateMap)
+        tree = Phylo.read(StringIO("(A:1,B:1)ancestor;"), "newick")
+
+        labels = svc._label_internal_nodes(tree)
+
+        assert labels[id(tree.root)] == "ancestor"
+
     def test_rate_pipeline_uses_direct_tree_traversal(self, monkeypatch):
         svc = TraitRateMap.__new__(TraitRateMap)
         tree = Phylo.read(StringIO("((A:1,B:1):1,(C:1,D:1):1);"), "newick")
@@ -458,6 +572,52 @@ class TestBranchRates:
 
         assert len(branch_rates) == 6
         assert {entry["child"] for entry in branch_rates} >= {"A", "B", "C", "D"}
+
+    def test_branch_rate_boundaries_and_missing_values(self):
+        svc = TraitRateMap.__new__(TraitRateMap)
+        valid_tip = Clade(name="A", branch_length=0.0)
+        internal = Clade(
+            name=None,
+            branch_length=-1.0,
+            clades=[Clade(name="descendant")],
+        )
+        root = Clade(name=None, clades=[valid_tip, internal])
+        tree = Namespace(root=root)
+        orphan = Clade(name="orphan", branch_length=1.0)
+        no_parent_value = Clade(name="no-parent-value", branch_length=1.0)
+        no_child_value = Clade(name="no-child-value", branch_length=1.0)
+        missing_parent = Clade(name="missing-parent")
+        parent_map = {
+            id(valid_tip): root,
+            id(internal): root,
+            id(no_parent_value): missing_parent,
+            id(no_child_value): root,
+        }
+        node_values = {
+            id(root): 1.0,
+            id(valid_tip): 2.0,
+            id(internal): 3.0,
+            id(no_parent_value): 4.0,
+        }
+
+        rates = svc._compute_branch_rates(
+            tree,
+            node_values,
+            parent_map,
+            {},
+            [
+                root,
+                orphan,
+                no_parent_value,
+                no_child_value,
+                valid_tip,
+                internal,
+            ],
+        )
+
+        assert [entry["child"] for entry in rates] == ["A", "unknown"]
+        assert all(entry["parent"] == "root" for entry in rates)
+        assert all(entry["branch_length"] > 0 for entry in rates)
 
     def test_ancestral_reconstruction_weighted_polytomy(self):
         svc = TraitRateMap.__new__(TraitRateMap)

--- a/tests/unit/services/tree/test_tree_space.py
+++ b/tests/unit/services/tree/test_tree_space.py
@@ -1050,6 +1050,48 @@ class TestSpeciesTree:
         assert coords.shape == (11, 2)
 
 
+class TestVisualization:
+    def test_scatter_plot_marks_species_tree_and_skips_empty_cluster(
+        self, tmp_path, default_args
+    ):
+        output = tmp_path / "tree-space-species.png"
+        svc = TreeSpace(default_args)
+        coords = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 1.0],
+                [0.5, 0.5],
+            ]
+        )
+        labels = np.array([0, 0, 1])
+
+        svc._plot(coords, labels, k=2, species_tree_idx=2, output_path=str(output))
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_heatmap_writes_clustered_distance_plot(self, tmp_path, default_args):
+        output = tmp_path / "tree-space-heatmap.png"
+        svc = TreeSpace(default_args)
+        dist = np.array(
+            [
+                [0.0, 0.1, 0.8, 0.9],
+                [0.1, 0.0, 0.7, 0.8],
+                [0.8, 0.7, 0.0, 0.2],
+                [0.9, 0.8, 0.2, 0.0],
+            ]
+        )
+
+        svc._plot_heatmap(
+            dist,
+            ["tree_1", "tree_2", "tree_3", "tree_4"],
+            str(output),
+        )
+
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+
 class TestEndToEnd:
     @patch("builtins.print")
     def test_creates_png(self, mocked_print, tmp_path):
@@ -1140,6 +1182,53 @@ class TestEndToEnd:
         assert "coordinates" in payload
         assert len(payload["coordinates"]) == 10
         assert payload["output_file"] == str(output)
+
+    def test_rejects_fewer_than_three_gene_trees(self, tmp_path):
+        tree_file = tmp_path / "two-trees.nwk"
+        tree_file.write_text("((A,B),(C,D));\n((A,C),(B,D));\n")
+        svc = TreeSpace(
+            _base_args(
+                trees=str(tree_file),
+                output=str(tmp_path / "unused.png"),
+            )
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc.run()
+
+        assert exc_info.value.messages == [
+            "At least 3 gene trees are required for tree space analysis.",
+            "Only 2 tree(s) found.",
+        ]
+
+    @patch("builtins.print")
+    def test_heatmap_species_tree_distance_matrix_and_json_output(
+        self, mocked_print, tmp_path
+    ):
+        output = tmp_path / "tree-space-heatmap.png"
+        distance_matrix = tmp_path / "tree-distances.csv"
+        svc = TreeSpace(
+            _base_args(
+                output=str(output),
+                species_tree=TREE_SIMPLE,
+                heatmap=True,
+                distance_matrix=str(distance_matrix),
+                json=True,
+                k=2,
+                seed=42,
+            )
+        )
+
+        svc.run()
+
+        payload = json.loads(mocked_print.call_args.args[0])
+        assert payload["n_trees"] == 10
+        assert payload["n_clusters"] == 2
+        assert payload["species_tree_cluster"] in {1, 2}
+        assert output.exists()
+        csv_lines = distance_matrix.read_text().splitlines()
+        assert csv_lines[0].endswith(",species_tree")
+        assert len(csv_lines) == 12
 
     def test_json_coordinates_vectorizes_rounding(self, monkeypatch):
         def fail_round(*_args, **_kwargs):

--- a/tests/unit/services/tree/test_tree_space.py
+++ b/tests/unit/services/tree/test_tree_space.py
@@ -330,6 +330,88 @@ class TestTreeParsing:
         with pytest.raises(PhykitUserError):
             svc._parse_trees_from_source("no_such_file.nwk")
 
+    def test_path_list_rejects_missing_tree(self, tmp_path, default_args):
+        tree_list = tmp_path / "tree-list.txt"
+        tree_list.write_text("missing-tree.nwk\n")
+        svc = TreeSpace(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_list))
+
+        assert exc_info.value.code == 2
+        assert "missing-tree.nwk" in exc_info.value.messages[0]
+
+    def test_empty_tree_source_is_rejected(self, tmp_path, default_args):
+        tree_file = tmp_path / "empty.nwk"
+        tree_file.write_text("\n# no trees\n")
+        svc = TreeSpace(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert exc_info.value.code == 2
+        assert exc_info.value.messages == ["No trees found in input."]
+
+    def test_malformed_newick_is_reported_as_user_error(
+        self, tmp_path, default_args, monkeypatch
+    ):
+        tree_file = tmp_path / "malformed.nwk"
+        tree_file.write_text("((A,B),(C,D));\n")
+        svc = TreeSpace(default_args)
+        monkeypatch.setattr(
+            tree_space_module.Phylo,
+            "read",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad tree")),
+        )
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._parse_trees_from_source(str(tree_file))
+
+        assert exc_info.value.messages == ["Failed to parse Newick trees: bad tree"]
+
+    def test_tip_lookup_falls_back_to_tree_api(self, default_args, monkeypatch):
+        svc = TreeSpace(default_args)
+        tree = Phylo.read(StringIO("((A,B),(C,D));"), "newick")
+        monkeypatch.setattr(Tree, "calculate_terminal_names_fast", lambda _tree: None)
+
+        assert svc._tips(tree) == {"A", "B", "C", "D"}
+
+    def test_prune_to_taxa_falls_back_to_individual_pruning(
+        self, default_args, monkeypatch
+    ):
+        svc = TreeSpace(default_args)
+        tree = Phylo.read(StringIO("((A,B),(C,D));"), "newick")
+        monkeypatch.setattr(Tree, "calculate_terminal_clades_fast", lambda _tree: None)
+        monkeypatch.setattr(
+            Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            lambda *_args: False,
+        )
+
+        pruned = svc._prune_to_taxa(tree, {"A", "C", "D"})
+
+        assert {tip.name for tip in pruned.get_terminals()} == {"A", "C", "D"}
+
+    def test_shared_taxa_requires_gene_trees(self, default_args):
+        svc = TreeSpace(default_args)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._get_shared_taxa([])
+
+        assert exc_info.value.messages == ["No gene trees provided."]
+
+    def test_shared_taxa_requires_at_least_four_taxa(self, default_args):
+        svc = TreeSpace(default_args)
+        trees = [
+            Phylo.read(StringIO("((A,B),C);"), "newick"),
+            Phylo.read(StringIO("((A,C),B);"), "newick"),
+        ]
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._get_shared_taxa(trees)
+
+        assert "Only 3 shared taxa found." in exc_info.value.messages
+
     def test_shared_taxa(self, default_args):
         svc = TreeSpace(default_args)
         trees = svc._parse_trees_from_source(GENE_TREES)
@@ -487,6 +569,72 @@ class TestDistanceMatrix:
         assert observed == [
             "A", "B", "internal", "C", "D", "internal", "internal",
         ]
+
+    def test_direct_postorder_rejects_nonstandard_tree_objects(self):
+        class MissingRoot:
+            pass
+
+        class MissingChildClades:
+            root = type("Root", (), {"clades": [object()]})()
+
+        assert TreeSpace._postorder_clades_direct(MissingRoot()) is None
+        assert TreeSpace._postorder_clades_direct(MissingChildClades()) is None
+
+    def test_split_extractors_fall_back_to_find_clades(
+        self, monkeypatch, default_args, kf_args
+    ):
+        tree = Phylo.read(StringIO("((A:1,B:1):2,(C:1,D:1):3);"), "newick")
+        all_taxa = frozenset({"A", "B", "C", "D"})
+        monkeypatch.setattr(
+            TreeSpace,
+            "_postorder_clades_direct",
+            lambda _self, _tree: None,
+        )
+
+        assert TreeSpace(default_args)._extract_splits(tree, all_taxa) == {
+            frozenset({"A", "B"})
+        }
+        assert TreeSpace(kf_args)._extract_splits_with_lengths(tree, all_taxa) == {
+            frozenset({"A", "B"}): 3.0
+        }
+
+    def test_split_extractors_ignore_nonshared_and_multifurcating_clades(
+        self, default_args, kf_args
+    ):
+        tree = Phylo.read(
+            StringIO("((A:1,B:1,C:1):2,(D:1,E:1):3,(F:1,G:1):4,H:1);"),
+            "newick",
+        )
+        all_taxa = frozenset({"A", "B", "C", "D", "E", "F", "G"})
+
+        splits = TreeSpace(default_args)._extract_splits(tree, all_taxa)
+        split_lengths = TreeSpace(kf_args)._extract_splits_with_lengths(tree, all_taxa)
+
+        assert frozenset({"A", "B", "C"}) not in splits
+        assert frozenset({"A", "B", "C"}) not in split_lengths
+        assert frozenset({"D", "E"}) in splits
+        assert split_lengths[frozenset({"D", "E"})] == 3.0
+
+    def test_distance_helpers_handle_minimal_and_empty_inputs(self, default_args):
+        svc = TreeSpace(default_args)
+
+        assert svc._compute_rf_distance(set(), set(), n_taxa=3) == 0.0
+        np.testing.assert_array_equal(
+            svc._build_rf_distance_matrix_from_splits([], n_taxa=4),
+            np.zeros((0, 0)),
+        )
+        np.testing.assert_array_equal(
+            svc._build_rf_distance_matrix_from_splits([set(), set()], n_taxa=4),
+            np.zeros((2, 2)),
+        )
+        np.testing.assert_array_equal(
+            svc._build_kf_distance_matrix_from_splits([]),
+            np.zeros((0, 0)),
+        )
+        np.testing.assert_array_equal(
+            svc._build_kf_distance_matrix_from_splits([{}, {}]),
+            np.zeros((2, 2)),
+        )
 
     def test_extract_splits_uses_direct_postorder_for_standard_tree(
         self, monkeypatch, default_args
@@ -710,6 +858,44 @@ class TestDimensionalityReduction:
         coords = svc._reduce_dimensions(dist, "tsne", 42)
         assert coords.shape == (10, 2)
 
+    def test_umap_reports_missing_optional_dependency(
+        self, default_args, monkeypatch
+    ):
+        svc = TreeSpace(default_args)
+        monkeypatch.setitem(sys.modules, "umap", None)
+
+        with pytest.raises(PhykitUserError) as exc_info:
+            svc._reduce_dimensions(np.zeros((4, 4)), "umap", 42)
+
+        assert "umap-learn is required" in exc_info.value.messages[0]
+
+    def test_umap_uses_precomputed_distances(self, default_args, monkeypatch):
+        calls = {}
+
+        class FakeUMAP:
+            def __init__(self, **kwargs):
+                calls["kwargs"] = kwargs
+
+            def fit_transform(self, matrix):
+                calls["matrix"] = matrix
+                return np.ones((len(matrix), 2))
+
+        fake_module = type("FakeUmapModule", (), {"UMAP": FakeUMAP})()
+        monkeypatch.setitem(sys.modules, "umap", fake_module)
+        matrix = np.zeros((4, 4))
+
+        coords = TreeSpace(default_args)._reduce_dimensions(matrix, "umap", 7)
+
+        np.testing.assert_array_equal(coords, np.ones((4, 2)))
+        assert calls == {
+            "kwargs": {
+                "n_components": 2,
+                "metric": "precomputed",
+                "random_state": 7,
+            },
+            "matrix": matrix,
+        }
+
 
 class TestClustering:
     def test_clustering_labels_valid(self, default_args):
@@ -719,7 +905,7 @@ class TestClustering:
         dist = svc._build_distance_matrix(trees, shared, "rf")
         labels, k = svc._spectral_cluster(dist, None, 42)
         assert len(labels) == 10
-        assert all(0 <= l < k for l in labels)
+        assert all(0 <= label < k for label in labels)
         assert k >= 2
 
     def test_spectral_cluster_uses_condensed_distances(
@@ -790,6 +976,21 @@ class TestClustering:
         labels, k = svc._spectral_cluster(dist, None, 42)
         # k should be a reasonable number
         assert 2 <= k <= len(trees) // 2
+
+    def test_auto_k_handles_two_samples(self, default_args):
+        affinity = np.eye(2)
+
+        assert TreeSpace(default_args)._auto_detect_k(affinity) == 2
+
+    def test_spectral_cluster_handles_all_zero_distances(self, default_args):
+        labels, k = TreeSpace(default_args)._spectral_cluster(
+            np.zeros((4, 4)),
+            2,
+            None,
+        )
+
+        assert len(labels) == 4
+        assert k == 2
 
     def test_auto_detect_k_matches_dense_laplacian_reference(
         self, default_args, monkeypatch

--- a/tests/unit/services/tree/test_vcv_utils.py
+++ b/tests/unit/services/tree/test_vcv_utils.py
@@ -171,6 +171,16 @@ def _wrap_binary_child_lists_no_reversed(clade):
 
 
 class TestBuildVcvMatrix:
+    def test_tip_name_helper_falls_back_to_get_terminals(self, monkeypatch):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        monkeypatch.setattr(
+            vcv_utils.Tree,
+            "calculate_terminal_names_fast",
+            staticmethod(lambda _tree: None),
+        )
+
+        assert vcv_utils._get_tip_names(tree) == ["A", "B"]
+
     def test_symmetric(self):
         tree = _read_tree(TREE_SIMPLE)
         tips = sorted(t.name for t in tree.get_terminals())
@@ -229,6 +239,156 @@ class TestBuildVcvMatrix:
         assert vcv[1, 2] == pytest.approx(0.5, rel=1e-6)
         # A-B shared path = 0 (diverge at root)
         assert vcv[0, 1] == pytest.approx(0.0, abs=1e-6)
+
+    def test_distance_fallback_matches_expected_matrix(self, monkeypatch):
+        tree = _make_tree("(A:1.0,(B:0.5,C:0.5):0.5);")
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_matrix_fast",
+            lambda _tree, _names: None,
+        )
+
+        observed = build_vcv_matrix(tree, ["A", "B", "C"])
+
+        expected = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.5],
+            [0.0, 0.5, 1.0],
+        ])
+        np.testing.assert_allclose(observed, expected)
+
+    def test_parent_map_fallback_matches_expected_matrix(self, monkeypatch):
+        tree = _make_tree("(A:1.0,(B:0.5,C:0.5):0.5);")
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(
+            tree,
+            "distance",
+            lambda *_args: pytest.fail("distance fallback should not be used"),
+        )
+
+        observed = build_vcv_matrix(tree, ["A", "B", "C"])
+
+        expected = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.5],
+            [0.0, 0.5, 1.0],
+        ])
+        np.testing.assert_allclose(observed, expected)
+
+    def test_branch_accumulation_rejects_disconnected_terminal(self):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        terminals = {tip.name: tip for tip in tree.get_terminals()}
+
+        observed = vcv_utils._build_vcv_from_branch_accumulation(
+            ["A", "B"],
+            terminals,
+            tree.root,
+            {},
+            lambda clade: clade.branch_length or 0.0,
+        )
+
+        assert observed is None
+
+    def test_fast_builder_rejects_unsupported_tree_shapes(self, monkeypatch):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+
+        assert vcv_utils._build_vcv_matrix_fast(object(), ["A"]) is None
+
+        class RootOnlyTree:
+            root = object()
+
+        assert vcv_utils._build_vcv_matrix_fast(RootOnlyTree(), ["A"]) is None
+
+        monkeypatch.setattr(tree, "get_terminals", lambda: 1)
+        assert vcv_utils._build_vcv_matrix_fast(tree, ["A"]) is None
+
+    def test_fast_builder_rejects_missing_requested_tip(self, monkeypatch):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+
+        assert vcv_utils._build_vcv_matrix_fast(tree, ["C"]) is None
+
+    def test_descendant_builder_rejects_invalid_inputs(self):
+        tree = _make_tree("(A:1.0,B:1.0);")
+
+        def branch_length(clade):
+            return clade.branch_length or 0.0
+
+        assert (
+            vcv_utils._build_vcv_from_descendant_indices(
+                ["A", "A"], tree.root, branch_length
+            )
+            is None
+        )
+        assert (
+            vcv_utils._build_vcv_from_descendant_indices(
+                ["A"], object(), branch_length
+            )
+            is None
+        )
+
+        class MalformedRoot:
+            clades = [object()]
+
+        assert (
+            vcv_utils._build_vcv_from_descendant_indices(
+                ["A"], MalformedRoot(), branch_length
+            )
+            is None
+        )
+
+    def test_descendant_builder_handles_empty_and_subset_orders(self):
+        tree = _make_tree("(A:0.0,B:2.0,X:3.0);")
+
+        def branch_length(clade):
+            return clade.branch_length or 0.0
+
+        empty = vcv_utils._build_vcv_from_descendant_indices(
+            [], tree.root, branch_length
+        )
+        contiguous = vcv_utils._build_vcv_from_descendant_indices(
+            ["A", "B"], tree.root, branch_length
+        )
+        shuffled = vcv_utils._build_vcv_from_descendant_indices(
+            ["B", "A"], tree.root, branch_length
+        )
+
+        assert empty.shape == (0, 0)
+        np.testing.assert_allclose(contiguous, np.diag([0.0, 2.0]))
+        np.testing.assert_allclose(shuffled, np.diag([2.0, 0.0]))
+
+    def test_descendant_builder_rejects_duplicate_or_missing_tree_tips(self):
+        def branch_length(clade):
+            return clade.branch_length or 0.0
+
+        duplicate = _make_tree("(A:1.0,A:2.0);")
+        missing = _make_tree("(A:1.0,B:1.0);")
+
+        assert (
+            vcv_utils._build_vcv_from_descendant_indices(
+                ["A"], duplicate.root, branch_length
+            )
+            is None
+        )
+        assert (
+            vcv_utils._build_vcv_from_descendant_indices(
+                ["A", "C"], missing.root, branch_length
+            )
+            is None
+        )
 
     def test_real_tree_fast_path_does_not_call_distance(self, monkeypatch):
         tree = _make_tree("(A:1.0,(B:0.5,C:0.5):0.5);")
@@ -425,6 +585,141 @@ class TestBuildVcvMatrix:
         expected = build_vcv_matrix(transformed, tips)
 
         np.testing.assert_allclose(vcv, expected)
+
+    def test_transformed_vcv_copy_fallback_transforms_positive_branches(self):
+        tree = _make_tree("(A:1.0,(B:0.0,C):2.0);")
+
+        observed = vcv_utils._build_transformed_vcv_matrix_fallback(
+            tree,
+            ["A", "B", "C"],
+            lambda branch_length: branch_length + 1.0,
+        )
+
+        expected = np.array([
+            [2.0, 0.0, 0.0],
+            [0.0, 3.0, 3.0],
+            [0.0, 3.0, 3.0],
+        ])
+        np.testing.assert_allclose(observed, expected)
+        assert tree.find_any(name="A").branch_length == pytest.approx(1.0)
+
+    def test_transformed_vcv_uses_copy_fallback_for_legacy_tree(self, monkeypatch):
+        marker = np.array([[7.0]])
+        calls = []
+
+        def fallback(tree, names, transform):
+            calls.append((tree, names, transform(2.0)))
+            return marker
+
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_transformed_vcv_matrix_fallback",
+            fallback,
+        )
+        legacy_tree = object()
+
+        observed = build_transformed_vcv_matrix(
+            legacy_tree, ["A"], lambda value: value * 3.0
+        )
+
+        assert observed is marker
+        assert calls == [(legacy_tree, ["A"], 6.0)]
+
+    def test_transformed_vcv_falls_back_when_parent_map_is_unavailable(
+        self, monkeypatch
+    ):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        marker = np.array([[8.0]])
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(
+            vcv_utils,
+            "build_object_parent_map",
+            lambda _tree: (_ for _ in ()).throw(AttributeError),
+        )
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_transformed_vcv_matrix_fallback",
+            lambda *_args: marker,
+        )
+
+        observed = build_transformed_vcv_matrix(tree, ["A"], lambda value: value)
+
+        assert observed is marker
+
+    def test_transformed_vcv_parent_map_fallback_matches_expected_matrix(
+        self, monkeypatch
+    ):
+        tree = _make_tree("(A:0.0,(B:1.0,C:1.0):2.0);")
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+
+        observed = build_transformed_vcv_matrix(
+            tree, ["A", "B", "C"], lambda value: value * 2.0
+        )
+
+        expected = np.array([
+            [0.0, 0.0, 0.0],
+            [0.0, 6.0, 4.0],
+            [0.0, 4.0, 6.0],
+        ])
+        np.testing.assert_allclose(observed, expected)
+
+    def test_transformed_vcv_falls_back_for_invalid_terminals(self, monkeypatch):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        marker = np.array([[9.0]])
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(tree, "get_terminals", lambda: 1)
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_transformed_vcv_matrix_fallback",
+            lambda *_args: marker,
+        )
+
+        observed = build_transformed_vcv_matrix(tree, ["A"], lambda value: value)
+
+        assert observed is marker
+
+    def test_transformed_vcv_falls_back_for_missing_or_disconnected_tip(
+        self, monkeypatch
+    ):
+        tree = _make_tree("(A:1.0,B:1.0);")
+        marker = np.array([[10.0]])
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_descendant_indices",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_transformed_vcv_matrix_fallback",
+            lambda *_args: marker,
+        )
+
+        missing = build_transformed_vcv_matrix(
+            tree, ["C"], lambda value: value
+        )
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_vcv_from_branch_accumulation",
+            lambda *_args: None,
+        )
+        disconnected = build_transformed_vcv_matrix(
+            tree, ["A"], lambda value: value
+        )
+
+        assert missing is marker
+        assert disconnected is marker
 
     def test_explicit_root_branch_length_matches_distance_formula(self):
         tree = _make_tree("(A:1.0,(B:0.5,C:0.5):0.5):2.0;")

--- a/tests/unit/services/tree/test_vcv_utils.py
+++ b/tests/unit/services/tree/test_vcv_utils.py
@@ -1140,6 +1140,121 @@ class TestBuildDiscordanceVcv:
             "E",
         }
 
+    def test_copy_prune_legacy_tree_returns_original_when_all_taxa_shared(self):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class LegacyTree:
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B")]
+
+            def get_terminals(self):
+                return self.tips
+
+        tree = LegacyTree()
+
+        observed = _copy_prune_gene_tree_to_shared_taxa(tree, {"A", "B"})
+
+        assert observed is tree
+
+    def test_copy_prune_legacy_tree_uses_generic_pruning(self, monkeypatch):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class LegacyTree:
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B")]
+
+            def get_terminals(self):
+                return self.tips
+
+            def prune(self, tip):
+                self.tips.remove(tip)
+
+        tree = LegacyTree()
+        monkeypatch.setattr(vcv_utils.pickle, "dumps", lambda value, **_kwargs: value)
+        monkeypatch.setattr(vcv_utils.pickle, "loads", lambda value: value)
+
+        observed = _copy_prune_gene_tree_to_shared_taxa(tree, {"A"})
+
+        assert observed is tree
+        assert [tip.name for tip in observed.get_terminals()] == ["A"]
+
+    def test_copy_prune_legacy_tree_recovers_after_terminal_lookup_error(
+        self, monkeypatch
+    ):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class LegacyTree:
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B")]
+                self.terminal_calls = 0
+
+            def get_terminals(self):
+                self.terminal_calls += 1
+                if self.terminal_calls == 1:
+                    raise AttributeError("legacy traversal is temporarily unavailable")
+                return self.tips
+
+            def prune(self, tip):
+                self.tips.remove(tip)
+
+        tree = LegacyTree()
+        monkeypatch.setattr(vcv_utils.pickle, "dumps", lambda value, **_kwargs: value)
+        monkeypatch.setattr(vcv_utils.pickle, "loads", lambda value: value)
+
+        observed = _copy_prune_gene_tree_to_shared_taxa(tree, {"A"})
+
+        assert [tip.name for tip in observed.get_terminals()] == ["A"]
+
+    def test_copy_prune_malformed_tree_falls_back_to_generic_api(
+        self, monkeypatch
+    ):
+        class Tip:
+            def __init__(self, name):
+                self.name = name
+
+        class Root:
+            clades = [object()]
+
+        class MalformedTree:
+            root = Root()
+
+            def __init__(self):
+                self.tips = [Tip("A"), Tip("B")]
+
+            def get_terminals(self):
+                return self.tips
+
+            def prune(self, tip):
+                self.tips.remove(tip)
+
+        tree = MalformedTree()
+        monkeypatch.setattr(vcv_utils.pickle, "dumps", lambda value, **_kwargs: value)
+        monkeypatch.setattr(vcv_utils.pickle, "loads", lambda value: value)
+
+        observed = _copy_prune_gene_tree_to_shared_taxa(tree, {"A"})
+
+        assert [tip.name for tip in observed.get_terminals()] == ["A"]
+
+    def test_copy_prune_multifurcation_uses_per_tip_fallback(self, monkeypatch):
+        tree = _make_tree("(A:1.0,B:1.0,C:1.0);")
+        monkeypatch.setattr(
+            vcv_utils.Tree,
+            "_prune_terminal_objects_batch_standard_tree",
+            staticmethod(lambda *_args: False),
+        )
+
+        observed = _copy_prune_gene_tree_to_shared_taxa(tree, {"A", "C"})
+
+        assert observed is not tree
+        assert {tip.name for tip in observed.get_terminals()} == {"A", "C"}
+        assert {tip.name for tip in tree.get_terminals()} == {"A", "B", "C"}
+
     def test_copy_prune_gene_tree_fallback_prunes_terminal_objects(self, monkeypatch):
         gt = _make_tree("(A:1,B:1);")
         original_prune = TreeMixin.prune
@@ -1179,6 +1294,134 @@ class TestBuildDiscordanceVcv:
         pruned = _copy_prune_gene_tree_to_shared_taxa(gt, {"A", "C"})
 
         assert pruned is gt
+
+    def test_pruned_subset_builder_rejects_unsupported_inputs(self):
+        tree = _make_tree("(A:1.0,B:1.0);")
+
+        assert _build_pruned_subset_vcv_matrix(object(), ["A"]) is None
+        assert _build_pruned_subset_vcv_matrix(tree, ["A", "A"]) is None
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        assert _build_pruned_subset_vcv_matrix(MalformedTree(), ["A"]) is None
+
+    def test_pruned_subset_builder_rejects_duplicate_or_missing_tips(self):
+        duplicate = _make_tree("(A:1.0,A:2.0);")
+        missing = _make_tree("(A:1.0,B:1.0);")
+
+        assert _build_pruned_subset_vcv_matrix(duplicate, ["A"]) is None
+        assert _build_pruned_subset_vcv_matrix(missing, ["A", "C"]) is None
+
+    def test_pruned_subset_builder_ignores_zero_length_branches(self):
+        tree = _make_tree("(A:0.0,B:2.0,X:3.0);")
+
+        observed = _build_pruned_subset_vcv_matrix(tree, ["A", "B"])
+
+        np.testing.assert_allclose(observed, np.diag([0.0, 2.0]))
+
+    def test_missing_branch_length_validation_supports_legacy_tree(self):
+        class Clade:
+            def __init__(self, branch_length):
+                self.branch_length = branch_length
+
+        class LegacyTree:
+            def __init__(self, branch_length):
+                self.root = Clade(None)
+                self.child = Clade(branch_length)
+
+            def find_clades(self):
+                return [self.root, self.child]
+
+        assert _gene_tree_has_missing_branch_lengths(LegacyTree(None)) is True
+        assert _gene_tree_has_missing_branch_lengths(LegacyTree(1.0)) is False
+
+    def test_missing_branch_length_validation_recovers_from_malformed_child(self):
+        class Clade:
+            def __init__(self, branch_length, clades=None):
+                self.branch_length = branch_length
+                if clades is not None:
+                    self.clades = clades
+
+        malformed = Clade(1.0)
+        missing = Clade(None, [])
+        root = Clade(None, [malformed])
+
+        class MalformedTree:
+            def __init__(self, include_missing):
+                self.root = root
+                self.include_missing = include_missing
+
+            def find_clades(self):
+                clades = [self.root, malformed]
+                if self.include_missing:
+                    clades.append(missing)
+                return clades
+
+        assert _gene_tree_has_missing_branch_lengths(MalformedTree(True)) is True
+        assert _gene_tree_has_missing_branch_lengths(MalformedTree(False)) is False
+
+    def test_tip_and_branch_scan_delegates_for_legacy_or_malformed_tree(
+        self, monkeypatch
+    ):
+        expected = (["A", "B"], True)
+        monkeypatch.setattr(vcv_utils, "_get_tip_names", lambda _tree: expected[0])
+        monkeypatch.setattr(
+            vcv_utils,
+            "_gene_tree_has_missing_branch_lengths",
+            lambda _tree: expected[1],
+        )
+
+        assert _get_tip_names_and_missing_branch_lengths(object()) == expected
+
+        class MalformedRoot:
+            clades = [object()]
+
+        class MalformedTree:
+            root = MalformedRoot()
+
+        assert _get_tip_names_and_missing_branch_lengths(MalformedTree()) == expected
+
+    def test_discordance_vcv_copy_prunes_when_subset_builder_declines(
+        self, monkeypatch
+    ):
+        species = _make_tree("((A:1,B:1):1,(C:1,D:1):1);")
+        gene_tree = _make_tree("((A:1,B:1):1,(C:1,(D:1,E:1):1):1);")
+        copy_prune = vcv_utils._copy_prune_gene_tree_to_shared_taxa
+        copied = []
+
+        def track_copy_prune(tree, shared_taxa):
+            copied.append((tree, shared_taxa))
+            return copy_prune(tree, shared_taxa)
+
+        monkeypatch.setattr(
+            vcv_utils,
+            "_build_pruned_subset_vcv_matrix",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(
+            vcv_utils,
+            "_copy_prune_gene_tree_to_shared_taxa",
+            track_copy_prune,
+        )
+
+        observed, metadata = build_discordance_vcv(
+            species, [gene_tree], ["A", "B", "C", "D"]
+        )
+
+        assert observed.shape == (4, 4)
+        assert metadata["shared_taxa"] == ["A", "B", "C", "D"]
+        assert copied == [(gene_tree, {"A", "B", "C", "D"})]
+        assert {tip.name for tip in gene_tree.get_terminals()} == {
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+        }
 
     def test_too_few_shared_taxa(self):
         tree = _read_tree(TREE_SIMPLE)
@@ -1244,6 +1487,19 @@ class TestNearestPsd:
         result, corrected, min_eval = _nearest_psd(matrix)
 
         np.testing.assert_array_almost_equal(result, matrix)
+        assert corrected is False
+        assert min_eval == pytest.approx(1.0)
+
+    def test_eigenvalue_fast_path_failure_uses_full_decomposition(self, monkeypatch):
+        def fail_minimum_eigenvalue(*_args, **_kwargs):
+            raise TypeError("subset eigenvalue calculation is unavailable")
+
+        monkeypatch.setattr(vcv_utils, "eigvalsh", fail_minimum_eigenvalue)
+        matrix = np.eye(3)
+
+        observed, corrected, min_eval = _nearest_psd(matrix)
+
+        np.testing.assert_allclose(observed, matrix)
         assert corrected is False
         assert min_eval == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary

- raises exact local combined statement-and-branch coverage from 86.47% to 93.16492%
- raises merged Codecov coverage from 84.08% to 91.54%, above the 91.5% project gate
- adds focused behavioral coverage across shared helpers, alignment and tree workflows, CLI/error handling, numerical fallbacks, parsing, generic tree compatibility, simulations, colors, and plotting
- leaves every production module at or above 80% local combined coverage
- establishes stable gates of 90% for the unit suite and 91.5% for merged unit/integration coverage

## Coverage

| Metric | Baseline | Final | Change |
| --- | ---: | ---: | ---: |
| Local combined | 86.47% | 93.16492% | +6.69 points |
| Codecov | 84.08% | 91.54% | +7.46 points |
| Statements covered | 42,756 / 48,108 | 45,582 / 48,110 | +2,826 |
| Branches covered | 13,755 / 17,244 | 15,305 / 17,244 | +1,550 |
| Partial branches | 2,299 | 1,531 | -768 |

Codecov reports 44,039 fully covered lines, 2,542 misses, and 1,527 partials for `4066f016`. Codecov treats lines with partial branch coverage differently from the local Coverage.py aggregate, which accounts for the difference between 91.54% remote and 93.16492% local.

## Validation

- 6,126 unit tests passed
- 861 integration tests passed
- Python 3.10, 3.11, 3.12, and 3.13 GitHub Actions jobs passed
- strict Sphinx documentation build passed
- generated documentation, documentation contracts, and retrieval benchmark passed
- tutorials 01 through 21 passed against an isolated wheel installation
- wheel entry-point checks passed for all 321 console scripts
- isolated installed-wheel smoke checks passed for 110 canonical help commands
- Ubuntu and Windows wheel smoke jobs passed

Final CI: https://github.com/JLSteenwyk/PhyKIT/actions/runs/29622093235

Final Codecov report: https://app.codecov.io/github/JLSteenwyk/PhyKIT/commit/4066f016ce1a6dd681a491d0188b381e0bf819f5/tree/

## Notes

The suite still emits existing dependency and deprecation warnings from pytest-asyncio, Matplotlib, UMAP, and scikit-learn. No production behavior was changed solely to increase coverage.
